### PR TITLE
fix: remediate round 2 audit — execution layer (#34)

### DIFF
--- a/src/execution/Basalt.Execution/Mempool.cs
+++ b/src/execution/Basalt.Execution/Mempool.cs
@@ -60,9 +60,11 @@ public sealed class Mempool
     public bool Add(Transaction tx, bool raiseEvent = true)
     {
         // M-2: Pre-admission validation (signature, nonce, balance, gas)
+        // MED-01: Fork the state DB to isolate validation reads from concurrent block execution writes.
         if (_validator != null && _validationStateDb != null)
         {
-            var validation = _validator.Validate(tx, _validationStateDb);
+            var snapshot = _validationStateDb.Fork();
+            var validation = _validator.Validate(tx, snapshot);
             if (!validation.IsSuccess)
                 return false;
         }

--- a/src/execution/Basalt.Execution/Transaction.cs
+++ b/src/execution/Basalt.Execution/Transaction.cs
@@ -34,6 +34,10 @@ public sealed class Transaction
     public UInt256 GasPrice { get; init; }
     public UInt256 MaxFeePerGas { get; init; } = UInt256.Zero;
     public UInt256 MaxPriorityFeePerGas { get; init; } = UInt256.Zero;
+    /// <summary>
+    /// LOW-02: This is a mutable byte array. Callers must not mutate the contents after
+    /// construction, as doing so would invalidate the cached transaction hash.
+    /// </summary>
     public byte[] Data { get; init; } = [];
     /// <summary>
     /// L-3: Reserved for future use (e.g., transaction priority lanes).
@@ -50,6 +54,8 @@ public sealed class Transaction
     /// without revealing identity, issuer, or credential details.
     /// A BLAKE3 hash of serialized proofs is included in the signing payload (COMPL-02)
     /// to prevent relay nodes from stripping or modifying proofs.
+    /// LOW-02: Mutable array — callers must not mutate after construction
+    /// as doing so would invalidate the cached transaction hash.
     /// </summary>
     public ComplianceProof[] ComplianceProofs { get; init; } = [];
 
@@ -225,7 +231,7 @@ public sealed class Transaction
 public sealed class TransactionReceipt
 {
     public required Hash256 TransactionHash { get; init; }
-    public required Hash256 BlockHash { get; init; }
+    public required Hash256 BlockHash { get; set; }
     public required ulong BlockNumber { get; init; }
     public required int TransactionIndex { get; init; }
     public required Address From { get; init; }

--- a/src/execution/Basalt.Execution/TransactionExecutor.cs
+++ b/src/execution/Basalt.Execution/TransactionExecutor.cs
@@ -206,6 +206,11 @@ public sealed class TransactionExecutor
             // Refund unused gas to sender on canonical state
             var actualFee = effectiveGasPrice * new UInt256(effectiveGas);
             var refund = maxGasFee - actualFee;
+
+            // CRIT-02: Refund tx.Value when fork is not merged (deploy failed)
+            if (!result.Success && tx.Value > UInt256.Zero)
+                refund = UInt256.CheckedAdd(refund, tx.Value);
+
             if (refund > UInt256.Zero)
             {
                 senderState = stateDb.GetAccount(tx.Sender)!.Value;
@@ -227,7 +232,7 @@ public sealed class TransactionExecutor
                 GasUsed = effectiveGas,
                 Success = result.Success,
                 ErrorCode = result.Success ? BasaltErrorCode.Success : BasaltErrorCode.ContractDeployFailed,
-                PostStateRoot = stateDb.ComputeStateRoot(),
+                PostStateRoot = Hash256.Zero,
                 Logs = result.Logs,
                 EffectiveGasPrice = effectiveGasPrice,
             };
@@ -236,9 +241,13 @@ public sealed class TransactionExecutor
         {
             // C-1: Fork is discarded — no storage mutations leak to canonical state.
             // C-2: Nonce already incremented, max gas fee already debited.
-            // Refund (maxGasFee - fullGasCharge) where fullGasCharge = effectiveGasPrice * gasLimit
             var fullGasCharge = effectiveGasPrice * new UInt256(tx.GasLimit);
             var oogRefund = maxGasFee - fullGasCharge;
+
+            // CRIT-02: Refund tx.Value since fork was discarded
+            if (tx.Value > UInt256.Zero)
+                oogRefund = UInt256.CheckedAdd(oogRefund, tx.Value);
+
             if (oogRefund > UInt256.Zero)
             {
                 senderState = stateDb.GetAccount(tx.Sender)!.Value;
@@ -263,7 +272,9 @@ public sealed class TransactionExecutor
             // C-2: Still charge gas + increment nonce
             var sState = stateDb.GetAccount(tx.Sender) ?? AccountState.Empty;
             ChargeGasAndIncrementNonce(stateDb, tx.Sender, sState, maxGasFee, effectiveGasPrice, blockHeader);
-            return CreateReceipt(tx, blockHeader, txIndex, gasMeter.GasUsed, false,
+            // HIGH-03: Report tx.GasLimit as GasUsed (not 0) since the sender was charged maxGasFee.
+            // This ensures totalGasUsed in the block header is accurate.
+            return CreateReceipt(tx, blockHeader, txIndex, tx.GasLimit, false,
                 BasaltErrorCode.ContractNotFound, stateDb, effectiveGasPrice);
         }
 
@@ -334,6 +345,11 @@ public sealed class TransactionExecutor
             // Refund unused gas to sender on canonical state
             var actualFee = effectiveGasPrice * new UInt256(effectiveGas);
             var refund = maxGasFee - actualFee;
+
+            // CRIT-02: Refund tx.Value when fork is not merged (contract reverted/failed)
+            if (!result.Success && tx.Value > UInt256.Zero)
+                refund = UInt256.CheckedAdd(refund, tx.Value);
+
             if (refund > UInt256.Zero)
             {
                 senderState = stateDb.GetAccount(tx.Sender)!.Value;
@@ -355,7 +371,7 @@ public sealed class TransactionExecutor
                 GasUsed = effectiveGas,
                 Success = result.Success,
                 ErrorCode = result.Success ? BasaltErrorCode.Success : BasaltErrorCode.ContractCallFailed,
-                PostStateRoot = stateDb.ComputeStateRoot(),
+                PostStateRoot = Hash256.Zero,
                 Logs = result.Logs,
                 EffectiveGasPrice = effectiveGasPrice,
             };
@@ -366,6 +382,11 @@ public sealed class TransactionExecutor
             // C-2: Nonce incremented, max gas fee debited already.
             var fullGasCharge = effectiveGasPrice * new UInt256(tx.GasLimit);
             var oogRefund = maxGasFee - fullGasCharge;
+
+            // CRIT-02: Refund tx.Value since fork was discarded
+            if (tx.Value > UInt256.Zero)
+                oogRefund = UInt256.CheckedAdd(oogRefund, tx.Value);
+
             if (oogRefund > UInt256.Zero)
             {
                 senderState = stateDb.GetAccount(tx.Sender)!.Value;
@@ -636,14 +657,16 @@ public sealed class TransactionExecutor
         };
         stateDb.SetAccount(sender, senderState);
 
-        // Credit proposer tip from actual charge
+        // HIGH-02: Credit proposer tip using at least TxBase gas so the charged amount
+        // is properly accounted for. Previously gasUsed=0 meant no tip was credited,
+        // causing a protocol-level supply leak on failed transactions.
         if (!actualCharge.IsZero)
-            CreditProposerTip(stateDb, blockHeader, effectiveGasPrice, 0); // Tip from base gas only
+            CreditProposerTip(stateDb, blockHeader, effectiveGasPrice, GasTable.TxBase);
     }
 
     /// <summary>
     /// C-1: Merge contract state from a fork back into canonical state.
-    /// Copies the contract account and any storage that was modified on the fork.
+    /// Copies the contract account and all storage mutations made on the fork.
     /// </summary>
     private static void MergeForkState(IStateDatabase fork, IStateDatabase canonical, Address contractAddress)
     {
@@ -651,6 +674,20 @@ public sealed class TransactionExecutor
         var contractAccount = fork.GetAccount(contractAddress);
         if (contractAccount.HasValue)
             canonical.SetAccount(contractAddress, contractAccount.Value);
+
+        // CRIT-01: Merge storage mutations from the fork back to canonical.
+        // Without this, all SetStorage() calls during contract execution are silently lost.
+        foreach (var (contract, key) in fork.GetModifiedStorageKeys())
+        {
+            if (contract != contractAddress)
+                continue;
+
+            var value = fork.GetStorage(contract, key);
+            if (value != null)
+                canonical.SetStorage(contract, key, value);
+            else
+                canonical.DeleteStorage(contract, key);
+        }
     }
 
     /// <summary>
@@ -676,6 +713,8 @@ public sealed class TransactionExecutor
         ulong gasUsed, bool success, BasaltErrorCode errorCode, IStateDatabase stateDb,
         UInt256 effectiveGasPrice = default)
     {
+        // MED-03: PostStateRoot set to Hash256.Zero per-receipt to avoid O(n^2) ComputeStateRoot().
+        // The final state root is computed once in BlockBuilder after all txs execute.
         return new TransactionReceipt
         {
             TransactionHash = tx.Hash,
@@ -687,7 +726,7 @@ public sealed class TransactionExecutor
             GasUsed = gasUsed,
             Success = success,
             ErrorCode = errorCode,
-            PostStateRoot = stateDb.ComputeStateRoot(),
+            PostStateRoot = Hash256.Zero,
             EffectiveGasPrice = effectiveGasPrice,
         };
     }

--- a/src/execution/Basalt.Execution/VM/GasMeter.cs
+++ b/src/execution/Basalt.Execution/VM/GasMeter.cs
@@ -43,10 +43,11 @@ public sealed class GasMeter
 
     /// <summary>
     /// Add a gas refund (e.g. from storage deletion).
+    /// MED-04: Uses checked arithmetic to prevent silent overflow.
     /// </summary>
     public void AddRefund(ulong amount)
     {
-        GasRefund += amount;
+        checked { GasRefund += amount; }
     }
 
     /// <summary>

--- a/src/storage/Basalt.Storage/IStateDatabase.cs
+++ b/src/storage/Basalt.Storage/IStateDatabase.cs
@@ -33,6 +33,13 @@ public interface IStateDatabase
     /// Used for speculative block building during consensus proposals.
     /// </summary>
     IStateDatabase Fork();
+
+    /// <summary>
+    /// Returns the set of storage keys modified since this database was created or forked.
+    /// Used by TransactionExecutor.MergeForkState to copy dirty storage from a fork
+    /// back to the canonical state after successful contract execution.
+    /// </summary>
+    IReadOnlyCollection<(Address Contract, Hash256 Key)> GetModifiedStorageKeys() => [];
 }
 
 /// <summary>

--- a/src/storage/Basalt.Storage/InMemoryStateDb.cs
+++ b/src/storage/Basalt.Storage/InMemoryStateDb.cs
@@ -17,6 +17,7 @@ public sealed class InMemoryStateDb : IStateDatabase
 {
     private readonly Dictionary<Address, AccountState> _accounts = new();
     private readonly Dictionary<(Address, Hash256), byte[]> _storage = new();
+    private readonly HashSet<(Address, Hash256)> _dirtyStorageKeys = new();
 
     public AccountState? GetAccount(Address address)
     {
@@ -104,10 +105,14 @@ public sealed class InMemoryStateDb : IStateDatabase
     public void SetStorage(Address contract, Hash256 key, byte[] value)
     {
         _storage[(contract, key)] = value;
+        _dirtyStorageKeys.Add((contract, key));
     }
 
     public void DeleteStorage(Address contract, Hash256 key)
     {
         _storage.Remove((contract, key));
+        _dirtyStorageKeys.Add((contract, key));
     }
+
+    public IReadOnlyCollection<(Address Contract, Hash256 Key)> GetModifiedStorageKeys() => _dirtyStorageKeys;
 }


### PR DESCRIPTION
## Summary

Remediates all 14 findings (2 Critical, 3 High, 5 Medium, 4 Low) from the Round 2 security audit for the Execution layer.

### Critical
- **CRIT-01**: `MergeForkState()` now copies storage mutations from fork to canonical state via new `GetModifiedStorageKeys()` dirty tracking on `IStateDatabase`
- **CRIT-02**: Refunds `tx.Value` to sender on failed contract call/deploy when fork state is discarded (prevents permanent value loss)

### High
- **HIGH-01**: `BlockBuilder` accepts shared `TransactionExecutor` with staking/compliance deps instead of creating unconfigured internal one
- **HIGH-02**: `ChargeGasAndIncrementNonce` credits proposer with `TxBase` gas instead of zero
- **HIGH-03**: Contract-not-found receipt reports `tx.GasLimit` as `GasUsed` instead of 0

### Medium
- **MED-01**: Mempool forks stateDb before pre-admission validation (thread safety)
- **MED-02**: BlockBuilder updates receipt `BlockHash` after computing final header
- **MED-03**: Per-receipt `ComputeStateRoot()` replaced with `Hash256.Zero` (eliminates O(n²))
- **MED-04**: `GasMeter.AddRefund` uses checked arithmetic (overflow protection)
- **MED-05**: SDK contract timeout uses `Task.Run` + `WaitAsync` for preemptive cancellation

### Low
- **LOW-01**: `ContractBridge.GasRemaining` snapshot nature already documented (L-10)
- **LOW-02**: Document mutable byte array fields on Transaction
- **LOW-03**: Redundant signature verification already documented (L-5)
- **LOW-04**: Merkle tree domain separation bytes (0x00 leaves, 0x01 internal nodes)

## Test plan
- [x] 7 new tests covering CRIT-01, CRIT-02, HIGH-01, HIGH-03, MED-02, MED-04
- [x] All 2,334 tests pass
- [x] 0 build warnings, 0 errors

Closes #34