### PR TITLE
fix: remediate round 2 audit — compliance layer (#36)

### DIFF
--- a/src/compliance/Basalt.Compliance/ComplianceEvents.cs
+++ b/src/compliance/Basalt.Compliance/ComplianceEvents.cs
@@ -50,7 +50,12 @@ public sealed class ComplianceEvent
     /// <summary>Transfer amount (for transfer events).</summary>
     public ulong Amount { get; init; }
 
-    /// <summary>Unix timestamp (seconds) when the event occurred.</summary>
+    /// <summary>
+    /// Unix timestamp (seconds) when the event occurred.
+    /// LOW-02: Some audit events use DateTimeOffset.UtcNow for this field (provider approval,
+    /// attestation revocation, policy changes). This is metadata-only and NOT consensus-critical —
+    /// audit log timestamps are never used in block validation or state transitions.
+    /// </summary>
     public long Timestamp { get; init; }
 
     /// <summary>Human-readable details of the event.</summary>

--- a/src/execution/Basalt.Execution/TransactionExecutor.cs
+++ b/src/execution/Basalt.Execution/TransactionExecutor.cs
@@ -84,8 +84,11 @@ public sealed class TransactionExecutor
                 ? (ulong)recipientBalance.Lo : ulong.MaxValue;
             var txAmountForCompliance = tx.Value.Hi == 0 && (ulong)(tx.Value.Lo >> 64) == 0
                 ? (ulong)tx.Value.Lo : ulong.MaxValue;
+            // MED-01: Use Address.Zero as token address sentinel for native transfers.
+            // Previously tx.To (recipient) was passed as tokenAddress, which would look up
+            // the recipient's compliance policy instead of the native token policy.
             var outcome = _complianceVerifier.CheckTransferCompliance(
-                tx.To.ToArray(), tx.Sender.ToArray(), tx.To.ToArray(),
+                Address.Zero.ToArray(), tx.Sender.ToArray(), tx.To.ToArray(),
                 txAmountForCompliance, blockHeader.Timestamp, amountForCompliance);
             if (!outcome.Allowed)
                 return CreateReceipt(tx, blockHeader, txIndex, gasUsed, false, outcome.ErrorCode, stateDb);


### PR DESCRIPTION
## Summary

Remediates all 7 findings (1 High, 3 Medium, 3 Low) from the Round 2 security audit for the Compliance layer.

### High
- **HIGH-01**: Fix TOCTOU nullifier race — tentatively consume nullifier before Groth16 verification, roll back on failure

### Medium
- **MED-01**: Use `Address.Zero` as native transfer token address instead of `tx.To`
- **MED-02**: `IdentityRegistry.GetAttestation()` returns defensive copy
- **MED-03**: Document circuit-level credential expiry enforcement

### Low
- **LOW-01**: Simplify audit log eviction (`RemoveAt(0)` instead of `RemoveRange`)
- **LOW-02**: Document `DateTimeOffset.UtcNow` as metadata-only in audit events
- **LOW-03**: Document `hasTravelRuleData` default in interface wrapper

## Test plan
- [x] All existing tests pass (0 failures)
- [x] 0 build warnings, 0 errors

Closes #36