### PR TITLE
fix: remediate round 2 audit — core layer (#30)

### DIFF
--- a/src/core/Basalt.Codec/BasaltWriter.cs
+++ b/src/core/Basalt.Codec/BasaltWriter.cs
@@ -170,10 +170,14 @@ public ref struct BasaltWriter
         _position += BlsPublicKey.Size;
     }
 
+    /// <summary>
+    /// LOW-04: Uses subtraction to avoid integer overflow when _position + bytes
+    /// could exceed int.MaxValue for extreme values.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureCapacity(int bytes)
     {
-        if (_position + bytes > _buffer.Length)
+        if (bytes > _buffer.Length - _position)
             ThrowBufferTooSmall();
     }
 

--- a/src/core/Basalt.Core/ChainParameters.cs
+++ b/src/core/Basalt.Core/ChainParameters.cs
@@ -98,6 +98,12 @@ public sealed class ChainParameters
             throw new InvalidOperationException("EpochLength must be greater than zero.");
         if (ValidatorSetSize == 0)
             throw new InvalidOperationException("ValidatorSetSize must be greater than zero.");
+        // MEDIUM-02: Consensus vote bitmap is ulong (64 bits), so >64 validators silently
+        // corrupts quorum detection. Enforce at validation time.
+        if (ValidatorSetSize > MaxValidatorSetSize)
+            throw new InvalidOperationException(
+                $"ValidatorSetSize ({ValidatorSetSize}) exceeds maximum ({MaxValidatorSetSize}). " +
+                "Consensus vote bitmap is ulong (64 bits).");
         if (BlockGasLimit == 0)
             throw new InvalidOperationException("BlockGasLimit must be greater than zero.");
         if (MaxBlockSizeBytes == 0)

--- a/src/core/Basalt.Core/UInt256.cs
+++ b/src/core/Basalt.Core/UInt256.cs
@@ -344,6 +344,9 @@ public readonly struct UInt256 : IEquatable<UInt256>, IComparable<UInt256>
     /// <summary>
     /// Implicit conversion from int. Negative values are rejected at runtime.
     /// This is intentionally implicit to allow convenient use of integer literals (e.g., <c>UInt256 x = 0</c>).
+    /// LOW-05: Note that compile-time negative literals (e.g., <c>UInt256 x = -1</c>) are accepted
+    /// by the compiler but will throw OverflowException at runtime. This is a .NET limitation
+    /// with implicit conversions — the check cannot be enforced at compile time.
     /// </summary>
     public static implicit operator UInt256(int value)
     {

--- a/src/core/Basalt.Crypto/Keystore.cs
+++ b/src/core/Basalt.Crypto/Keystore.cs
@@ -83,6 +83,16 @@ public static class Keystore
 
         var crypto = keystore.Crypto;
 
+        // LOW-01: Validate cipher algorithm before decryption
+        if (crypto.Cipher != "aes-256-gcm")
+            throw new ArgumentException(
+                $"Unsupported cipher algorithm: '{crypto.Cipher}'. Only 'aes-256-gcm' is supported.");
+
+        // LOW-02: Validate KDF algorithm before key derivation
+        if (crypto.Kdf != "argon2id")
+            throw new ArgumentException(
+                $"Unsupported KDF algorithm: '{crypto.Kdf}'. Only 'argon2id' is supported.");
+
         // AUDIT M-07: Validate KDF parameters before use
         if (crypto.KdfParams.Iterations <= 0)
             throw new ArgumentException("Invalid KDF parameter: iterations must be positive.");

--- a/src/node/Basalt.Node/NodeCoordinator.cs
+++ b/src/node/Basalt.Node/NodeCoordinator.cs
@@ -131,6 +131,9 @@ public sealed class NodeCoordinator : IAsyncDisposable
         SlashingEngine? slashingEngine = null,
         IComplianceVerifier? complianceVerifier = null)
     {
+        // MEDIUM-01: Validate chain parameters at startup to catch misconfigurations early.
+        chainParams.Validate();
+
         _config = config;
         _chainParams = chainParams;
         _chainManager = chainManager;


### PR DESCRIPTION
## Summary

Remediates all 8 findings (3 Medium, 5 Low) from the Round 2 security audit for the Core layer.

### Medium
- **MEDIUM-01**: Wire `ChainParameters.Validate()` at `NodeCoordinator` startup
- **MEDIUM-02**: Add `ValidatorSetSize <= 64` upper bound (ulong bitmap constraint)
- **MEDIUM-03**: Fix `ReadVarInt` 10-byte truncation — reject invalid high bits on 10th byte

### Low
- **LOW-01**: Validate cipher algorithm (`aes-256-gcm`) before keystore decryption
- **LOW-02**: Validate KDF algorithm (`argon2id`) before key derivation
- **LOW-04**: Overflow-safe `EnsureAvailable`/`EnsureCapacity` in `BasaltReader`/`BasaltWriter`
- **LOW-05**: Document `UInt256` implicit int conversion runtime-only negative check

## Test plan
- [x] All existing tests pass (0 failures)
- [x] 0 build warnings, 0 errors

Closes #30