### PR TITLE
fix: remediate round 2 audit — consensus layer (#31)

### DIFF
--- a/src/consensus/Basalt.Consensus/EpochManager.cs
+++ b/src/consensus/Basalt.Consensus/EpochManager.cs
@@ -223,6 +223,11 @@ public sealed class EpochManager
         if (totalBlocks == 0)
             return;
 
+        // LOW-01: When InactivityThresholdPercent=0, threshold would be 0 blocks,
+        // causing ALL validators to be slashed. Skip inactivity slashing entirely.
+        if (_chainParams.InactivityThresholdPercent == 0)
+            return;
+
         // Clamp to [0, 100] to prevent overflow or slashing-all with invalid values
         var percent = Math.Min(_chainParams.InactivityThresholdPercent, 100u);
         // Ceiling division: validators must sign >= InactivityThresholdPercent of blocks


### PR DESCRIPTION
## Summary

Remediates all 6 findings (2 Medium, 4 Low) from the Round 2 security audit for the Consensus layer.

### Medium
- **MED-01**: Verify `VoterPublicKey` matches registered BLS key for `SenderId` in `HandleVote`
- **MED-02**: Add `lock` to `GetLeader()` and `GetValidatorsFromBitmap()` for thread safety

### Low
- **LOW-01**: Skip inactivity slashing when `InactivityThresholdPercent=0`
- **LOW-02**: Future block round creation documented as intentional (pipelining)
- **LOW-03**: BLS Proof-of-Possession tracked for future work (doc only)
- **LOW-04**: `Volatile.Read`/`Write` for `ConsensusRound.State` and `ViewChangeRequested`

## Test plan
- [x] All existing tests pass (0 failures)
- [x] 0 build warnings, 0 errors

Closes #31