### PR TITLE
fix: remediate round 2 audit — storage layer (#32)

### DIFF
--- a/src/api/Basalt.Api.Rest/RestApiEndpoints.cs
+++ b/src/api/Basalt.Api.Rest/RestApiEndpoints.cs
@@ -679,6 +679,9 @@ public static class RestApiEndpoints
         // If the contract storage format changes, this endpoint must be updated accordingly.
         app.MapGet("/v1/pools", () =>
         {
+            // S2-03: Fork state for consistent multi-read snapshot
+            var snapshot = stateDb.Fork();
+
             var contractAddr = new Address(new byte[]
             {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -686,7 +689,7 @@ public static class RestApiEndpoints
             });
 
             // Read _nextPoolId (key "sp_next")
-            var nextIdRaw = stateDb.GetStorage(contractAddr, Blake3Hasher.Hash(Encoding.UTF8.GetBytes("sp_next")));
+            var nextIdRaw = snapshot.GetStorage(contractAddr, Blake3Hasher.Hash(Encoding.UTF8.GetBytes("sp_next")));
             ulong poolCount = 0;
             if (nextIdRaw is { Length: >= 9 } && nextIdRaw[0] == 0x01)
                 poolCount = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(nextIdRaw.AsSpan(1));
@@ -697,19 +700,19 @@ public static class RestApiEndpoints
                 var idStr = i.ToString();
 
                 // Operator (key "sp_ops:{id}", tag 0x07 = string)
-                var opsRaw = stateDb.GetStorage(contractAddr, Blake3Hasher.Hash(Encoding.UTF8.GetBytes("sp_ops:" + idStr)));
+                var opsRaw = snapshot.GetStorage(contractAddr, Blake3Hasher.Hash(Encoding.UTF8.GetBytes("sp_ops:" + idStr)));
                 var operatorHex = opsRaw is { Length: > 1 } && opsRaw[0] == 0x07
                     ? Encoding.UTF8.GetString(opsRaw.AsSpan(1))
                     : "";
 
                 // Total stake (key "sp_total:{id}", tag 0x0A = UInt256)
-                var stakeRaw = stateDb.GetStorage(contractAddr, Blake3Hasher.Hash(Encoding.UTF8.GetBytes("sp_total:" + idStr)));
+                var stakeRaw = snapshot.GetStorage(contractAddr, Blake3Hasher.Hash(Encoding.UTF8.GetBytes("sp_total:" + idStr)));
                 var totalStake = stakeRaw is { Length: >= 33 } && stakeRaw[0] == 0x0A
                     ? new UInt256(stakeRaw.AsSpan(1, 32)).ToString()
                     : "0";
 
                 // Total rewards (key "sp_rewards:{id}", tag 0x0A = UInt256)
-                var rewardsRaw = stateDb.GetStorage(contractAddr, Blake3Hasher.Hash(Encoding.UTF8.GetBytes("sp_rewards:" + idStr)));
+                var rewardsRaw = snapshot.GetStorage(contractAddr, Blake3Hasher.Hash(Encoding.UTF8.GetBytes("sp_rewards:" + idStr)));
                 var totalRewards = rewardsRaw is { Length: >= 33 } && rewardsRaw[0] == 0x0A
                     ? new UInt256(rewardsRaw.AsSpan(1, 32)).ToString()
                     : "0";

--- a/src/storage/Basalt.Storage/Trie/NibblePath.cs
+++ b/src/storage/Basalt.Storage/Trie/NibblePath.cs
@@ -24,11 +24,15 @@ public readonly struct NibblePath : IEquatable<NibblePath>
 
     /// <summary>
     /// Get the nibble at the specified index.
+    /// S2-05: Validates index is within bounds.
     /// </summary>
     public byte this[int index]
     {
         get
         {
+            if ((uint)index >= (uint)_length)
+                throw new ArgumentOutOfRangeException(nameof(index), index,
+                    $"Index must be in range [0, {_length}).");
             int absoluteIndex = _offset + index;
             int byteIndex = absoluteIndex / 2;
             return (absoluteIndex % 2 == 0)
@@ -39,17 +43,23 @@ public readonly struct NibblePath : IEquatable<NibblePath>
 
     /// <summary>
     /// Create a sub-path starting from the given offset.
+    /// S2-05: Validates start is within bounds.
     /// </summary>
     public NibblePath Slice(int start)
     {
+        if (start < 0 || start > _length)
+            throw new ArgumentOutOfRangeException(nameof(start));
         return new NibblePath(_data, _offset + start, _length - start);
     }
 
     /// <summary>
     /// Create a sub-path with specified offset and length.
+    /// S2-05: Validates start and length are within bounds.
     /// </summary>
     public NibblePath Slice(int start, int length)
     {
+        if (start < 0 || length < 0 || start + length > _length)
+            throw new ArgumentOutOfRangeException(nameof(start));
         return new NibblePath(_data, _offset + start, length);
     }
 


### PR DESCRIPTION
## Summary

Remediates all 5 findings (1 Medium, 4 Low) from the Round 2 security audit for the Storage layer.

### Medium
- **S2-03**: Fork `stateDb` for consistent multi-read snapshot in `/v1/pools` endpoint

### Low
- **S2-01**: VarInt buffer sizing documented as conservative (existing comment)
- **S2-02**: Receipt VarInt buffer sizing documented similarly
- **S2-04**: `FlatStateDb.LoadFromPersistence` deletion sets documented as runtime-only
- **S2-05**: `NibblePath` indexer and `Slice()` bounds validation added

## Test plan
- [x] All existing tests pass (0 failures)
- [x] 0 build warnings, 0 errors

Closes #32