### PR TITLE
fix: remediate round 2 audit — SDK layer (#35)

### DIFF
--- a/src/sdk/Basalt.Sdk.Contracts/Standards/BST1155Token.cs
+++ b/src/sdk/Basalt.Sdk.Contracts/Standards/BST1155Token.cs
@@ -55,7 +55,8 @@ public partial class BST1155Token : IBST1155
 
         _balances.Set(BalanceKey(from, tokenId), fromBalance - amount);
         var toBalance = _balances.Get(BalanceKey(to, tokenId));
-        _balances.Set(BalanceKey(to, tokenId), toBalance + amount);
+        // N-1: Use checked addition to prevent silent overflow
+        _balances.Set(BalanceKey(to, tokenId), UInt256.CheckedAdd(toBalance, amount));
 
         Context.Emit(new TransferSingleEvent
         {
@@ -86,7 +87,8 @@ public partial class BST1155Token : IBST1155
             _balances.Set(BalanceKey(from, tokenIds[i]), fromBal - amount);
 
             var toBal = _balances.Get(BalanceKey(to, tokenIds[i]));
-            _balances.Set(BalanceKey(to, tokenIds[i]), toBal + amount);
+            // N-1: Use checked addition to prevent silent overflow
+            _balances.Set(BalanceKey(to, tokenIds[i]), UInt256.CheckedAdd(toBal, amount));
         }
 
         Context.Emit(new TransferBatchEvent

--- a/src/sdk/Basalt.Sdk.Contracts/Standards/BST4626Vault.cs
+++ b/src/sdk/Basalt.Sdk.Contracts/Standards/BST4626Vault.cs
@@ -171,8 +171,10 @@ public partial class BST4626Vault : BST20Token, IBST4626
             "VAULT: not admin");
 
         // C-6: Require actual asset transfer — prevents phantom yield injection
-        Context.CallContract(_assetAddress, "TransferFrom",
+        // N-4: Check TransferFrom return value to prevent phantom yield on failed transfer
+        var transferred = Context.CallContract<bool>(_assetAddress, "TransferFrom",
             Context.Caller, Context.Self, yieldAmount);
+        Context.Require(transferred, "VAULT: harvest transfer failed");
 
         var newTotal = TotalAssets() + yieldAmount;
         _totalAssets.Set(newTotal);

--- a/src/sdk/Basalt.Sdk.Contracts/Storage.cs
+++ b/src/sdk/Basalt.Sdk.Contracts/Storage.cs
@@ -144,6 +144,13 @@ public sealed class StorageValue<T> where T : struct
 /// <summary>
 /// Storage map for key-value storage in contracts.
 /// </summary>
+/// <remarks>
+/// N-5: Key collision — the colon delimiter in <see cref="FullKey"/> means a key like
+/// "abc:def" would collide with prefix "abc" + key "def". This is safe for current usage
+/// because all key patterns use hex-encoded addresses (no colons), ulong IDs (numeric),
+/// or known short identifiers (e.g. "owner", "admin"). If user-supplied free-text keys
+/// are ever supported, a non-printable delimiter (e.g. 0x00) should be used instead.
+/// </remarks>
 public sealed class StorageMap<TKey, TValue>
     where TKey : notnull
 {


### PR DESCRIPTION
## Summary
- **N-1 (Medium):** Use `UInt256.CheckedAdd` in BST-1155 `SafeTransferFrom` and `SafeBatchTransferFrom` to prevent silent balance overflow
- **N-2 (Medium):** Add `Governance.RefreshDelegation()` to re-read delegator stake from StakingPool, fixing permanently stale delegated voting power
- **N-3 (Medium):** Add `BridgeETH.ExpireDeposit()` for confirmed deposits past 2x expiry window, preventing indefinite fund lockup
- **N-4 (Low):** Check `TransferFrom` return value in `BST4626Vault.Harvest()` to prevent phantom yield on failed transfer
- **N-5 (Low):** Document `StorageMap` colon delimiter key collision safety for current key patterns

Closes #35

## Test plan
- [x] All 574 SDK tests pass
- [x] Full test suite passes (0 failures)
- [x] Clean build (0 warnings, 0 errors)