### PR TITLE
fix: remediate round 2 audit — confidentiality layer (#37)

### DIFF
--- a/src/confidentiality/Basalt.Confidentiality/Disclosure/DisclosureProof.cs
+++ b/src/confidentiality/Basalt.Confidentiality/Disclosure/DisclosureProof.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Basalt.Confidentiality.Crypto;
 using Basalt.Core;
 
@@ -59,7 +60,9 @@ public sealed class DisclosureProof
             return false;
 
         // F-15: If a commitment reference is provided, it must match the given commitment
-        if (proof.CommitmentRef != null && !proof.CommitmentRef.AsSpan().SequenceEqual(commitment))
+        // LOW-02: Use constant-time comparison to prevent timing side-channel attacks
+        if (proof.CommitmentRef != null &&
+            !CryptographicOperations.FixedTimeEquals(proof.CommitmentRef, commitment))
             return false;
 
         return PedersenCommitment.Open(commitment, proof.Value, proof.BlindingFactor);


### PR DESCRIPTION
## Summary
- **LOW-01:** Nonce overflow check in `PrivateChannel.CreateMessage()` — prevents wrap-around to 0
- **LOW-02:** Constant-time `CommitmentRef` comparison in `DisclosureProof.Verify()` via `CryptographicOperations.FixedTimeEquals()`
- **LOW-03:** Validate distinct party keys in `PrivateChannel` — reject channels where both parties use the same X25519 key

INFO-01 (TimeBoundViewingKey/CommitmentRef test coverage) is tracked separately as a test expansion task.

Closes #37

## Test plan
- [x] Clean build (0 warnings, 0 errors)
- [x] Full test suite passes (0 failures)