### PR TITLE
feat: RPC node mode for query-only block following

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ dotnet build
 dotnet test
 ```
 
-2,781 tests across 16 test projects covering core types, cryptography, codec serialization, storage, networking, consensus, execution (including DEX), API, compliance, bridge, confidentiality, node configuration, SDK contracts, analyzers, wallet, and end-to-end integration.
+2,789 tests across 16 test projects covering core types, cryptography, codec serialization, storage, networking, consensus, execution (including DEX), API, compliance, bridge, confidentiality, node configuration, SDK contracts, analyzers, wallet, and end-to-end integration.
 
 ### Run a Local Node
 
@@ -76,16 +76,19 @@ The node starts in standalone mode on the devnet (chain ID 31337) with a REST AP
 docker compose up --build
 ```
 
-Spins up 4 validator nodes with pre-configured genesis accounts, RocksDB persistent storage, and automatic peer discovery via static peer lists.
+Spins up 4 validator nodes and 1 RPC node with pre-configured genesis accounts, RocksDB persistent storage, and automatic peer discovery via static peer lists.
 
-| Validator | REST API | P2P |
-|-----------|----------|-----|
-| validator-0 | `localhost:5100` | `30300` |
-| validator-1 | `localhost:5101` | `30301` |
-| validator-2 | `localhost:5102` | `30302` |
-| validator-3 | `localhost:5103` | `30303` |
+| Service | REST API | P2P | Role |
+|---------|----------|-----|------|
+| validator-0 | `localhost:5100` | `30300` | Consensus validator |
+| validator-1 | `localhost:5101` | `30301` | Consensus validator |
+| validator-2 | `localhost:5102` | `30302` | Consensus validator |
+| validator-3 | `localhost:5103` | `30303` | Consensus validator |
+| rpc-0 | `localhost:5200` | -- | Read-only RPC node |
 
-Each validator has a Docker volume (`validator-N-data`) for RocksDB persistence and connects to all other validators via environment-configured peer lists. Health checks poll `/v1/status` every 5 seconds.
+The RPC node (`rpc-0`) syncs blocks from `validator-0` via HTTP and serves the full API without participating in consensus. It has no P2P port and no validator keys. Submitted transactions are forwarded to the validator.
+
+Each service has a Docker volume for RocksDB persistence. Health checks poll `/v1/status` (validators) or `/v1/health` (RPC) every 5 seconds.
 
 ### CLI
 
@@ -210,6 +213,8 @@ Basalt.sln                              (42 C# projects)
 | `GET` | `/v1/solvers` | List registered solvers |
 | `POST` | `/v1/solvers/register` | Register an external solver |
 | `GET` | `/v1/dex/intents/pending` | Pending swap intent hashes (for solvers) |
+| `GET` | `/v1/sync/status` | Sync source status (latest block, hash, chain ID) |
+| `GET` | `/v1/sync/blocks?from=&count=` | Bulk block fetch for sync (max 100) |
 | `GET` | `/metrics` | Prometheus metrics |
 | `WS` | `/ws/blocks` | Real-time block notifications |
 
@@ -219,6 +224,8 @@ The node is configured via environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `BASALT_MODE` | `auto` | Node mode: `auto`, `validator`, `rpc`, or `standalone` |
+| `BASALT_SYNC_SOURCE` | -- | HTTP URL of sync source (required for `rpc` mode) |
 | `BASALT_CHAIN_ID` | `31337` | Chain identifier |
 | `BASALT_NETWORK` | `basalt-devnet` | Network name |
 | `BASALT_VALIDATOR_INDEX` | `-1` | Validator index in the set (enables consensus mode when >= 0 and peers are set) |

--- a/deploy/testnet/Caddyfile
+++ b/deploy/testnet/Caddyfile
@@ -38,9 +38,11 @@ http://caldera.basalt.foundation {
 		reverse_proxy rpc-0:5000
 	}
 
-	# WebSocket
+	# WebSocket — disable response buffering for persistent connections
 	handle /ws/* {
-		reverse_proxy rpc-0:5000
+		reverse_proxy rpc-0:5000 {
+			flush_interval -1
+		}
 	}
 
 	# Health check

--- a/deploy/testnet/Caddyfile
+++ b/deploy/testnet/Caddyfile
@@ -30,22 +30,22 @@ http://caldera.basalt.foundation {
 :80 {
 	# REST API
 	handle /v1/* {
-		reverse_proxy validator-0:5000
+		reverse_proxy rpc-0:5000
 	}
 
 	# GraphQL
 	handle /graphql {
-		reverse_proxy validator-0:5000
+		reverse_proxy rpc-0:5000
 	}
 
 	# WebSocket
 	handle /ws/* {
-		reverse_proxy validator-0:5000
+		reverse_proxy rpc-0:5000
 	}
 
 	# Health check
 	handle /health {
-		reverse_proxy validator-0:5000 {
+		reverse_proxy rpc-0:5000 {
 			rewrite /v1/status
 		}
 	}

--- a/deploy/testnet/docker-compose.yml
+++ b/deploy/testnet/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - basalt-testnet
     restart: unless-stopped
     depends_on:
-      validator-0:
+      rpc-0:
         condition: service_healthy
       explorer:
         condition: service_started
@@ -158,11 +158,44 @@ services:
     cap_drop:
       - ALL
 
+  # ─── RPC Node 0 (public API, no consensus) ────────────────────────
+  rpc-0:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    container_name: basalt-rpc-0
+    environment:
+      - BASALT_MODE=rpc
+      - BASALT_SYNC_SOURCE=http://validator-0:5000
+      - BASALT_NETWORK=basalt-testnet
+      - BASALT_CHAIN_ID=4242
+      - ASPNETCORE_URLS=http://+:5000
+      - BASALT_DATA_DIR=/data/basalt
+    volumes:
+      - rpc-0-data:/data/basalt
+    networks:
+      - basalt-testnet
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:5000/v1/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    depends_on:
+      validator-0:
+        condition: service_healthy
+
 volumes:
   validator-0-data:
   validator-1-data:
   validator-2-data:
   validator-3-data:
+  rpc-0-data:
 
 networks:
   basalt-testnet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,11 +115,45 @@ services:
     cap_drop:
       - ALL
 
+  rpc-0:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: basalt-rpc-0
+    ports:
+      - "5200:5000"
+    environment:
+      - BASALT_MODE=rpc
+      - BASALT_SYNC_SOURCE=http://validator-0:5000
+      - BASALT_NETWORK=basalt-devnet
+      - BASALT_CHAIN_ID=31337
+      - ASPNETCORE_URLS=http://+:5000
+      - BASALT_DATA_DIR=/data/basalt
+    volumes:
+      - rpc-0-data:/data/basalt
+    networks:
+      - basalt-devnet
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/v1/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 15s
+    depends_on:
+      validator-0:
+        condition: service_healthy
+
 volumes:
   validator-0-data:
   validator-1-data:
   validator-2-data:
   validator-3-data:
+  rpc-0-data:
 
 networks:
   basalt-devnet:

--- a/src/api/Basalt.Api.Grpc/BasaltNodeService.cs
+++ b/src/api/Basalt.Api.Grpc/BasaltNodeService.cs
@@ -14,6 +14,7 @@ public sealed class BasaltNodeService : BasaltNode.BasaltNodeBase
     private readonly Mempool _mempool;
     private readonly TransactionValidator _validator;
     private readonly IStateDatabase _stateDb;
+    private readonly ITxForwarder? _txForwarder;
 
     /// <summary>H-3: Maximum concurrent SubscribeBlocks streams.</summary>
     private const int MaxSubscribeStreams = 100;
@@ -23,12 +24,14 @@ public sealed class BasaltNodeService : BasaltNode.BasaltNodeBase
         ChainManager chainManager,
         Mempool mempool,
         TransactionValidator validator,
-        IStateDatabase stateDb)
+        IStateDatabase stateDb,
+        ITxForwarder? txForwarder = null)
     {
         _chainManager = chainManager;
         _mempool = mempool;
         _validator = validator;
         _stateDb = stateDb;
+        _txForwarder = txForwarder;
     }
 
     public override Task<StatusReply> GetStatus(GetStatusRequest request, ServerCallContext context)
@@ -119,6 +122,9 @@ public sealed class BasaltNodeService : BasaltNode.BasaltNodeBase
             if (!_mempool.Add(tx))
                 throw new RpcException(new Status(StatusCode.AlreadyExists,
                     "Transaction already in mempool or mempool is full"));
+
+            // Forward to validator (RPC mode — gRPC txs bypass REST tx endpoint)
+            _ = _txForwarder?.ForwardAsync(tx, context.CancellationToken);
 
             return Task.FromResult(new TransactionReply
             {

--- a/src/api/Basalt.Api.Rest/FaucetEndpoint.cs
+++ b/src/api/Basalt.Api.Rest/FaucetEndpoint.cs
@@ -55,7 +55,8 @@ public static class FaucetEndpoint
         ChainParameters chainParams,
         byte[] faucetPrivateKey,
         ILogger? logger = null,
-        ChainManager? chainManager = null)
+        ChainManager? chainManager = null,
+        ITxForwarder? txForwarder = null)
     {
         _faucetPrivateKey = faucetPrivateKey;
         _logger = logger;
@@ -206,6 +207,9 @@ public static class FaucetEndpoint
 
             _logger?.LogInformation("Faucet tx {Hash} added to mempool (size={Size})",
                 signedTx.Hash.ToHexString()[..18] + "...", mempool.Count);
+
+            // Forward to validator (RPC mode — faucet txs bypass POST /v1/transactions)
+            _ = txForwarder?.ForwardAsync(signedTx, CancellationToken.None);
 
             // Record the request time
             _lastRequest[addrKey] = DateTimeOffset.UtcNow;

--- a/src/api/Basalt.Api.Rest/README.md
+++ b/src/api/Basalt.Api.Rest/README.md
@@ -35,6 +35,8 @@ RESTful HTTP API for the Basalt blockchain node. Provides endpoints for submitti
 | `GET` | `/v1/solvers` | List registered solvers |
 | `POST` | `/v1/solvers/register` | Register an external solver |
 | `GET` | `/v1/dex/intents/pending` | Pending swap intent hashes (for solvers) |
+| `GET` | `/v1/sync/status` | Sync source status (latest block, hash, chain ID) |
+| `GET` | `/v1/sync/blocks?from=&count=` | Bulk block fetch for sync (max 100, hex-encoded raw blocks) |
 | `GET` | `/metrics` | Prometheus-format metrics |
 | `WS` | `/ws/blocks` | Real-time block notifications |
 
@@ -95,13 +97,13 @@ curl -X POST http://localhost:5000/v1/faucet \
   -d '{"address":"0x..."}'
 ```
 
-The faucet directly debits a configurable faucet address and credits the recipient in the state database. Configurable via static properties on `FaucetEndpoint`:
+The faucet creates and signs a real transfer transaction submitted through the mempool. In RPC mode, faucet transactions are forwarded to the sync source validator via `HttpTxForwarder`. Configurable via static properties on `FaucetEndpoint`:
 
 - `DripAmount` -- amount in base units (default: 100 BSLT).
 - `CooldownSeconds` -- per-address cooldown (default: 60 seconds).
-- `FaucetAddress` -- source address (default: `Address.Zero`).
+- `FaucetAddress` -- derived from the well-known faucet private key.
 
-Returns `{"success":true,"message":"Sent 100 BSLT to 0x...","txHash":"0x0000..."}` on success. The `txHash` field is a placeholder (`Hash256.Zero`) since the faucet modifies state directly rather than creating a transaction.
+Returns `{"success":true,"message":"Sent 100 BSLT to 0x...","txHash":"0x..."}` on success.
 
 ### Read-Only Contract Call
 

--- a/src/api/Basalt.Api.Rest/RestApiEndpoints.cs
+++ b/src/api/Basalt.Api.Rest/RestApiEndpoints.cs
@@ -1591,25 +1591,6 @@ public sealed class SyncBlocksResponse
 /// <summary>
 /// Forwards transactions from RPC nodes to validators.
 /// </summary>
-public interface ITxForwarder
-{
-    Task ForwardAsync(Transaction tx, CancellationToken ct);
-}
-
-/// <summary>
-/// Mutable reference to an <see cref="ITxForwarder"/>. Allows the RPC mode branch in
-/// Program.cs to set the forwarder after endpoint registration, since
-/// <see cref="RestApiEndpoints.MapBasaltEndpoints"/> is called before mode detection.
-/// </summary>
-public sealed class TxForwarderRef : ITxForwarder
-{
-    private volatile ITxForwarder? _inner;
-
-    public void Set(ITxForwarder forwarder) => _inner = forwarder;
-
-    public Task ForwardAsync(Transaction tx, CancellationToken ct)
-        => _inner?.ForwardAsync(tx, ct) ?? Task.CompletedTask;
-}
 
 [JsonSerializable(typeof(SyncStatusResponse))]
 [JsonSerializable(typeof(SyncBlockEntry))]

--- a/src/api/Basalt.Api.Rest/RestApiEndpoints.cs
+++ b/src/api/Basalt.Api.Rest/RestApiEndpoints.cs
@@ -951,9 +951,12 @@ public static class RestApiEndpoints
                 ? BatchAuctionSolver.ComputeSpotPrice(reserves.Value.Reserve0, reserves.Value.Reserve1)
                 : UInt256.Zero;
 
-            // Precompute latest block timestamp for estimation fallback
+            // Precompute latest block timestamp (seconds) for estimation fallback.
+            // BlockHeader.Timestamp is in milliseconds — convert to seconds for the API.
             var latestBlock = chainManager.GetBlockByNumber(currentBlock);
-            var latestTs = latestBlock?.Header.Timestamp ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var latestTs = latestBlock != null
+                ? latestBlock.Header.Timestamp / 1000
+                : DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
             var points = new List<DexPricePointResponse>();
             for (ulong b = start; b <= end; b += step)
@@ -996,12 +999,12 @@ public static class RestApiEndpoints
                     price = spotPrice;
                 }
 
-                // Determine timestamp from block header, with estimation fallback
+                // Determine timestamp from block header (ms → s), with estimation fallback
                 long timestamp;
                 var block = chainManager.GetBlockByNumber(b);
                 if (block != null)
                 {
-                    timestamp = block.Header.Timestamp;
+                    timestamp = block.Header.Timestamp / 1000;
                 }
                 else
                 {
@@ -1023,7 +1026,7 @@ public static class RestApiEndpoints
                 {
                     var block = chainManager.GetBlockByNumber(b);
                     var timestamp = block != null
-                        ? block.Header.Timestamp
+                        ? block.Header.Timestamp / 1000
                         : latestTs - (long)(currentBlock - b) * (long)blockTimeMs / 1000;
 
                     points.Add(new DexPricePointResponse

--- a/src/api/Basalt.Api.Rest/RestApiEndpoints.cs
+++ b/src/api/Basalt.Api.Rest/RestApiEndpoints.cs
@@ -33,7 +33,9 @@ public static class RestApiEndpoints
         Storage.RocksDb.ReceiptStore? receiptStore = null,
         Microsoft.Extensions.Logging.ILogger? logger = null,
         ChainParameters? chainParams = null,
-        ISolverInfoProvider? solverProvider = null)
+        ISolverInfoProvider? solverProvider = null,
+        Storage.RocksDb.BlockStore? blockStore = null,
+        ITxForwarder? txForwarder = null)
     {
         // Helper: look up a receipt by tx hash (persistent store first, then in-memory fallback)
         Storage.RocksDb.ReceiptData? LookupReceipt(Hash256 txHash)
@@ -150,6 +152,10 @@ public static class RestApiEndpoints
                         Message = "Transaction already in mempool or mempool is full.",
                     });
                 }
+
+                // RPC mode: forward transaction to sync source (fire-and-forget)
+                if (txForwarder != null)
+                    _ = txForwarder.ForwardAsync(tx, CancellationToken.None);
 
                 return Microsoft.AspNetCore.Http.Results.Ok(new TransactionResponse
                 {
@@ -1090,6 +1096,53 @@ public static class RestApiEndpoints
                 });
             });
         }
+
+        // ── Sync endpoints (used by RPC nodes to fetch blocks from validators) ──
+
+        app.MapGet("/v1/sync/status", () =>
+        {
+            var latest = chainManager.LatestBlock;
+            return Microsoft.AspNetCore.Http.Results.Ok(new SyncStatusResponse
+            {
+                LatestBlock = latest?.Number ?? 0,
+                LatestHash = latest?.Hash.ToHexString() ?? Hash256.Zero.ToHexString(),
+                ChainId = chainParams?.ChainId ?? 0,
+            });
+        });
+
+        app.MapGet("/v1/sync/blocks", (ulong from, int? count) =>
+        {
+            if (blockStore == null)
+                return Microsoft.AspNetCore.Http.Results.StatusCode(501);
+
+            var requestedCount = Math.Min(count ?? 100, 100);
+            var blocks = new List<SyncBlockEntry>();
+
+            for (ulong n = from; n < from + (ulong)requestedCount; n++)
+            {
+                var raw = blockStore.GetRawBlockByNumber(n);
+                if (raw == null)
+                    break;
+
+                var meta = blockStore.GetByNumber(n);
+                blocks.Add(new SyncBlockEntry
+                {
+                    Number = n,
+                    Hash = meta?.Hash.ToHexString() ?? "",
+                    RawHex = Convert.ToHexString(raw),
+                    CommitBitmap = blockStore.GetCommitBitmap(n),
+                });
+            }
+
+            return Microsoft.AspNetCore.Http.Results.Ok(new SyncBlocksResponse
+            {
+                Blocks = blocks.ToArray(),
+            });
+        });
+
+        // ── Transaction forwarding hook ──
+        // When txForwarder is set (RPC mode), fire-and-forget forward after mempool add.
+        // The forwarding is wired inside the POST /v1/transactions handler via the txForwarder parameter.
     }
 }
 
@@ -1511,6 +1564,57 @@ public sealed class DexPriceHistoryResponse
     [JsonPropertyName("blockTimeMs")] public uint BlockTimeMs { get; set; }
 }
 
+// ── Sync DTOs ──
+
+public sealed class SyncStatusResponse
+{
+    [JsonPropertyName("latestBlock")] public ulong LatestBlock { get; set; }
+    [JsonPropertyName("latestHash")] public string LatestHash { get; set; } = "";
+    [JsonPropertyName("chainId")] public uint ChainId { get; set; }
+}
+
+public sealed class SyncBlockEntry
+{
+    [JsonPropertyName("number")] public ulong Number { get; set; }
+    [JsonPropertyName("hash")] public string Hash { get; set; } = "";
+    [JsonPropertyName("rawHex")] public string RawHex { get; set; } = "";
+    [JsonPropertyName("commitBitmap")] public ulong? CommitBitmap { get; set; }
+}
+
+public sealed class SyncBlocksResponse
+{
+    [JsonPropertyName("blocks")] public SyncBlockEntry[] Blocks { get; set; } = [];
+}
+
+// ── Transaction forwarding interface (RPC mode) ──
+
+/// <summary>
+/// Forwards transactions from RPC nodes to validators.
+/// </summary>
+public interface ITxForwarder
+{
+    Task ForwardAsync(Transaction tx, CancellationToken ct);
+}
+
+/// <summary>
+/// Mutable reference to an <see cref="ITxForwarder"/>. Allows the RPC mode branch in
+/// Program.cs to set the forwarder after endpoint registration, since
+/// <see cref="RestApiEndpoints.MapBasaltEndpoints"/> is called before mode detection.
+/// </summary>
+public sealed class TxForwarderRef : ITxForwarder
+{
+    private volatile ITxForwarder? _inner;
+
+    public void Set(ITxForwarder forwarder) => _inner = forwarder;
+
+    public Task ForwardAsync(Transaction tx, CancellationToken ct)
+        => _inner?.ForwardAsync(tx, ct) ?? Task.CompletedTask;
+}
+
+[JsonSerializable(typeof(SyncStatusResponse))]
+[JsonSerializable(typeof(SyncBlockEntry))]
+[JsonSerializable(typeof(SyncBlockEntry[]))]
+[JsonSerializable(typeof(SyncBlocksResponse))]
 [JsonSerializable(typeof(TransactionRequest))]
 [JsonSerializable(typeof(TransactionResponse))]
 [JsonSerializable(typeof(BlockResponse))]

--- a/src/consensus/Basalt.Consensus/PipelinedConsensus.cs
+++ b/src/consensus/Basalt.Consensus/PipelinedConsensus.cs
@@ -47,7 +47,9 @@ public sealed class PipelinedConsensus
     private ulong _minNextView;
 
     // Callbacks
-    public event Action<Hash256, byte[], ulong>? OnBlockFinalized;
+    // Result-based: returns true if the block was successfully applied to the chain.
+    // _lastFinalizedBlock only advances when the callback confirms success.
+    public Func<Hash256, byte[], ulong, bool>? OnBlockFinalized;
     public event Action<ulong>? OnViewChange;
 
     /// <summary>
@@ -564,14 +566,32 @@ public sealed class PipelinedConsensus
         // If this is the next expected block, finalize immediately
         if (blockNumber == _lastFinalizedBlock + 1)
         {
+            // Only advance _lastFinalizedBlock if the callback confirms success.
+            // This prevents a gap where consensus thinks a block is finalized but
+            // the chain never applied it (e.g., timestamp rejection or ApplyBlock failure).
+            var success = OnBlockFinalized?.Invoke(hash, data, commitBitmap) ?? true;
+            if (!success)
+            {
+                _logger.LogWarning("Block {Block} finalization callback failed — not advancing _lastFinalizedBlock",
+                    blockNumber);
+                return;
+            }
+
             _lastFinalizedBlock = blockNumber;
-            OnBlockFinalized?.Invoke(hash, data, commitBitmap);
 
             // Drain any buffered blocks that are now sequential
             while (_pendingFinalizations.TryRemove(_lastFinalizedBlock + 1, out var pending))
             {
+                var drainSuccess = OnBlockFinalized?.Invoke(pending.Hash, pending.Data, pending.Bitmap) ?? true;
+                if (!drainSuccess)
+                {
+                    _logger.LogWarning("Buffered block {Block} finalization callback failed — stopping drain",
+                        _lastFinalizedBlock + 1);
+                    // Re-buffer so it can be retried
+                    _pendingFinalizations.TryAdd(_lastFinalizedBlock + 1, pending);
+                    break;
+                }
                 _lastFinalizedBlock = _lastFinalizedBlock + 1;
-                OnBlockFinalized?.Invoke(pending.Hash, pending.Data, pending.Bitmap);
                 _logger.LogInformation("Drained buffered finalization for block {Block}", _lastFinalizedBlock);
             }
         }

--- a/src/consensus/Basalt.Consensus/README.md
+++ b/src/consensus/Basalt.Consensus/README.md
@@ -49,7 +49,7 @@ var pipeline = new PipelinedConsensus(
     validatorSet, localPeerId, privateKey, blsSigner, logger,
     lastFinalizedBlock: 0);  // IBlsSigner is required, lastFinalizedBlock is optional
 
-pipeline.OnBlockFinalized += (hash, data, commitBitmap) => { /* commit block */ };
+pipeline.OnBlockFinalized = (hash, data, commitBitmap) => { /* commit block */ return true; };
 pipeline.OnViewChange += (newView) => { /* leader rotation */ };
 pipeline.OnBehindDetected += (blockNumber) => { /* trigger sync */ };
 

--- a/src/execution/Basalt.Execution/ChainManager.cs
+++ b/src/execution/Basalt.Execution/ChainManager.cs
@@ -189,6 +189,28 @@ public sealed class ChainManager
     }
 
     /// <summary>
+    /// Roll back the chain to the given target block, removing all blocks after it.
+    /// Used during fork recovery to revert to the last common ancestor.
+    /// </summary>
+    public void RollbackTo(Block targetBlock)
+    {
+        lock (_lock)
+        {
+            var toRemove = _blocksByNumber.Keys.Where(n => n > targetBlock.Number).ToList();
+            foreach (var number in toRemove)
+            {
+                if (_blocksByNumber.Remove(number, out var block))
+                    _blocksByHash.Remove(block.Hash);
+            }
+
+            // Ensure the target block is tracked
+            _blocksByHash[targetBlock.Hash] = targetBlock;
+            _blocksByNumber[targetBlock.Number] = targetBlock;
+            _latestBlock = targetBlock;
+        }
+    }
+
+    /// <summary>
     /// H-9: Evict old blocks beyond the retention window to prevent unbounded memory growth.
     /// Retains genesis (block 0) and the most recent MaxInMemoryBlocks blocks.
     /// Must be called under _lock.

--- a/src/execution/Basalt.Execution/ITxForwarder.cs
+++ b/src/execution/Basalt.Execution/ITxForwarder.cs
@@ -1,0 +1,24 @@
+namespace Basalt.Execution;
+
+/// <summary>
+/// Forwards transactions to an upstream node (e.g., from RPC to validator).
+/// </summary>
+public interface ITxForwarder
+{
+    Task ForwardAsync(Transaction tx, CancellationToken ct);
+}
+
+/// <summary>
+/// Mutable reference to an <see cref="ITxForwarder"/>. Allows the RPC mode branch in
+/// Program.cs to set the forwarder after endpoint registration, since
+/// MapBasaltEndpoints is called before mode detection.
+/// </summary>
+public sealed class TxForwarderRef : ITxForwarder
+{
+    private volatile ITxForwarder? _inner;
+
+    public void Set(ITxForwarder forwarder) => _inner = forwarder;
+
+    public Task ForwardAsync(Transaction tx, CancellationToken ct)
+        => _inner?.ForwardAsync(tx, ct) ?? Task.CompletedTask;
+}

--- a/src/explorer/Basalt.Explorer/Pages/Dashboard.razor
+++ b/src/explorer/Basalt.Explorer/Pages/Dashboard.razor
@@ -131,6 +131,7 @@
         await LoadData();
 
         WsService.OnNewBlock += HandleNewBlock;
+        WsService.OnConnected += HandleConnected;
         _ = WsService.ConnectAsync();
 
         // Increase poll interval as fallback
@@ -142,6 +143,12 @@
                 await InvokeAsync(StateHasChanged);
             }
         }, null, 10000, 10000);
+    }
+
+    private async void HandleConnected()
+    {
+        try { await InvokeAsync(StateHasChanged); }
+        catch (ObjectDisposedException) { }
     }
 
     // M-4: Wrap async void handler in try-catch to prevent unobserved exceptions
@@ -196,6 +203,7 @@
     {
         _timer?.Dispose();
         WsService.OnNewBlock -= HandleNewBlock;
+        WsService.OnConnected -= HandleConnected;
         return ValueTask.CompletedTask;
     }
 }

--- a/src/explorer/Basalt.Explorer/Pages/Dashboard.razor
+++ b/src/explorer/Basalt.Explorer/Pages/Dashboard.razor
@@ -138,10 +138,8 @@
         _timer = new Timer(async _ =>
         {
             if (!WsService.IsConnected)
-            {
                 await LoadData();
-                await InvokeAsync(StateHasChanged);
-            }
+            await InvokeAsync(StateHasChanged);
         }, null, 10000, 10000);
     }
 

--- a/src/explorer/Basalt.Explorer/Services/BlockWebSocketService.cs
+++ b/src/explorer/Basalt.Explorer/Services/BlockWebSocketService.cs
@@ -15,13 +15,20 @@ public sealed class BlockWebSocketService : IAsyncDisposable
     private int _reconnectAttempts;
 
     public event Action<WebSocketBlockEvent>? OnNewBlock;
+    public event Action? OnConnected;
     public bool IsConnected => _ws?.State == WebSocketState.Open;
 
     public BlockWebSocketService(string nodeUrl)
     {
         var uri = new Uri(nodeUrl);
         var wsScheme = uri.Scheme == "https" ? "wss" : "ws";
-        _wsUrl = $"{wsScheme}://{uri.Host}:{uri.Port}/ws/blocks";
+        // Omit default ports (443 for wss, 80 for ws) — explicit default ports
+        // cause a Host header mismatch with Cloudflare Tunnel routing.
+        var isDefaultPort = (wsScheme == "wss" && uri.Port == 443) ||
+                            (wsScheme == "ws" && uri.Port == 80);
+        _wsUrl = isDefaultPort
+            ? $"{wsScheme}://{uri.Host}/ws/blocks"
+            : $"{wsScheme}://{uri.Host}:{uri.Port}/ws/blocks";
     }
 
     public async Task ConnectAsync()
@@ -33,6 +40,7 @@ public sealed class BlockWebSocketService : IAsyncDisposable
         {
             await _ws.ConnectAsync(new Uri(_wsUrl), _cts.Token);
             _reconnectAttempts = 0; // LOW-03: Reset on successful connection
+            OnConnected?.Invoke();
             _ = ReceiveLoop(_cts.Token);
         }
         catch
@@ -90,6 +98,7 @@ public sealed class BlockWebSocketService : IAsyncDisposable
                 _ws = new ClientWebSocket();
                 await _ws.ConnectAsync(new Uri(_wsUrl), ct);
                 _reconnectAttempts = 0; // Reset on successful reconnect
+                OnConnected?.Invoke();
                 _ = ReceiveLoop(ct);
             }
             catch { /* give up reconnecting */ }

--- a/src/network/Basalt.Network/MessageCodec.cs
+++ b/src/network/Basalt.Network/MessageCodec.cs
@@ -160,6 +160,16 @@ public static class MessageCodec
                 WriteUInt64Array(ref writer, syncResp.CommitBitmaps);
                 break;
 
+            case ForkHashRequestMessage forkReq:
+                writer.WriteUInt64(forkReq.BlockNumber);
+                break;
+
+            case ForkHashResponseMessage forkResp:
+                writer.WriteUInt64(forkResp.BlockNumber);
+                writer.WriteHash256(forkResp.BlockHash);
+                writer.WriteBool(forkResp.HasBlock);
+                break;
+
             case IHaveMessage iHave:
                 WriteHashArray(ref writer, iHave.MessageIds);
                 break;
@@ -272,6 +282,18 @@ public static class MessageCodec
             MessageType.ConsensusAggregateVote => ReadAggregateVote(ref reader, senderId, timestamp),
             MessageType.SyncRequest => ReadSyncRequest(ref reader, senderId, timestamp),
             MessageType.SyncResponse => ReadSyncResponse(ref reader, senderId, timestamp),
+            MessageType.ForkHashRequest => new ForkHashRequestMessage
+            {
+                SenderId = senderId, Timestamp = timestamp,
+                BlockNumber = reader.ReadUInt64(),
+            },
+            MessageType.ForkHashResponse => new ForkHashResponseMessage
+            {
+                SenderId = senderId, Timestamp = timestamp,
+                BlockNumber = reader.ReadUInt64(),
+                BlockHash = reader.ReadHash256(),
+                HasBlock = reader.ReadBool(),
+            },
             MessageType.IHave => new IHaveMessage
             {
                 SenderId = senderId, Timestamp = timestamp,
@@ -741,6 +763,8 @@ public static class MessageCodec
             AggregateVoteMessage => 8 + 8 + 32 + 1 + BlsSignature.Size + 8,
             SyncRequestMessage => 8 + 4,
             SyncResponseMessage m => EstimateByteArraysSize(m.Blocks) + 10 + (m.CommitBitmaps.Length * 8),
+            ForkHashRequestMessage => 8,
+            ForkHashResponseMessage => 8 + Hash256.Size + 1,
             IHaveMessage m => 10 + (m.MessageIds.Length * Hash256.Size),
             IWantMessage m => 10 + (m.MessageIds.Length * Hash256.Size),
             GraftMessage => 0,

--- a/src/network/Basalt.Network/Messages.cs
+++ b/src/network/Basalt.Network/Messages.cs
@@ -31,6 +31,8 @@ public enum MessageType : byte
     // Sync
     SyncRequest = 0x40,
     SyncResponse = 0x41,
+    ForkHashRequest = 0x42,
+    ForkHashResponse = 0x43,
 
     // Gossip protocol (Episub)
     IHave = 0x50,
@@ -467,4 +469,29 @@ public sealed class SolverSolutionMessage : NetworkMessage
 
     /// <summary>Ed25519 signature of BLAKE3(blockNumber || poolId || clearingPrice).</summary>
     public Signature SolverSignature { get; init; }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Fork Detection Messages
+// ════════════════════════════════════════════════════════════════════
+
+/// <summary>
+/// Request the block hash at a specific height from a peer.
+/// Used during fork detection to binary-search for the fork point.
+/// </summary>
+public sealed class ForkHashRequestMessage : NetworkMessage
+{
+    public override MessageType Type => MessageType.ForkHashRequest;
+    public ulong BlockNumber { get; init; }
+}
+
+/// <summary>
+/// Response with the block hash at the requested height.
+/// </summary>
+public sealed class ForkHashResponseMessage : NetworkMessage
+{
+    public override MessageType Type => MessageType.ForkHashResponse;
+    public ulong BlockNumber { get; init; }
+    public Hash256 BlockHash { get; init; }
+    public bool HasBlock { get; init; }
 }

--- a/src/node/Basalt.Node/BlockApplier.cs
+++ b/src/node/Basalt.Node/BlockApplier.cs
@@ -1,0 +1,352 @@
+using Basalt.Consensus;
+using Basalt.Consensus.Staking;
+using Basalt.Core;
+using Basalt.Execution;
+using Basalt.Storage;
+using Basalt.Storage.RocksDb;
+using Basalt.Api.Rest;
+using Microsoft.Extensions.Logging;
+
+namespace Basalt.Node;
+
+/// <summary>
+/// Result of applying a single block to state.
+/// </summary>
+public sealed class BlockApplyResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public List<TransactionReceipt>? Receipts { get; init; }
+}
+
+/// <summary>
+/// Shared block-application logic used by NodeCoordinator (consensus finalization + sync)
+/// and BlockSyncService (RPC node HTTP sync). Encapsulates:
+/// <list type="number">
+/// <item>Transaction execution via <see cref="TransactionExecutor"/></item>
+/// <item>DEX settlement via <see cref="BlockBuilder.ApplyDexSettlement"/></item>
+/// <item>Chain state update via <see cref="ChainManager.AddBlock"/></item>
+/// <item>Mempool pruning and base fee update</item>
+/// <item>RocksDB persistence (blocks + receipts)</item>
+/// <item>Epoch transitions via <see cref="EpochManager"/></item>
+/// <item>WebSocket broadcast and Prometheus metrics</item>
+/// </list>
+/// </summary>
+public sealed class BlockApplier
+{
+    private readonly ChainParameters _chainParams;
+    private readonly ChainManager _chainManager;
+    private readonly Mempool _mempool;
+    private readonly TransactionExecutor _txExecutor;
+    private readonly BlockBuilder? _blockBuilder;
+    private readonly BlockStore? _blockStore;
+    private readonly ReceiptStore? _receiptStore;
+    private readonly EpochManager? _epochManager;
+    private readonly StakingState? _stakingState;
+    private readonly IStakingPersistence? _stakingPersistence;
+    private readonly WebSocketHandler _wsHandler;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Fired when an epoch transition occurs. The caller (NodeCoordinator) can hook this
+    /// to rewire consensus-specific components (leader selector, consensus engine).
+    /// Provides the new ValidatorSet and the block number at which the transition occurred.
+    /// </summary>
+    public event Action<ValidatorSet, ulong>? OnEpochTransition;
+
+    public BlockApplier(
+        ChainParameters chainParams,
+        ChainManager chainManager,
+        Mempool mempool,
+        TransactionExecutor txExecutor,
+        BlockBuilder? blockBuilder,
+        BlockStore? blockStore,
+        ReceiptStore? receiptStore,
+        EpochManager? epochManager,
+        StakingState? stakingState,
+        IStakingPersistence? stakingPersistence,
+        WebSocketHandler wsHandler,
+        ILogger logger)
+    {
+        _chainParams = chainParams;
+        _chainManager = chainManager;
+        _mempool = mempool;
+        _txExecutor = txExecutor;
+        _blockBuilder = blockBuilder;
+        _blockStore = blockStore;
+        _receiptStore = receiptStore;
+        _epochManager = epochManager;
+        _stakingState = stakingState;
+        _stakingPersistence = stakingPersistence;
+        _wsHandler = wsHandler;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Execute transactions and DEX settlement against the given state database.
+    /// Does NOT add the block to the chain or persist — the caller controls that.
+    /// Returns receipts (or null if no transactions).
+    /// </summary>
+    public List<TransactionReceipt>? ExecuteBlock(Block block, IStateDatabase stateDb)
+    {
+        List<TransactionReceipt>? receipts = null;
+
+        if (block.Transactions.Count > 0)
+        {
+            receipts = new List<TransactionReceipt>(block.Transactions.Count);
+            for (int i = 0; i < block.Transactions.Count; i++)
+            {
+                var receipt = _txExecutor.Execute(block.Transactions[i], stateDb, block.Header, i);
+                receipts.Add(receipt);
+            }
+        }
+
+        // Run DEX settlement (TWAP carry-forward + limit order matching)
+        if (_blockBuilder != null)
+        {
+            var dexReceipts = _blockBuilder.ApplyDexSettlement(stateDb, block.Header);
+            if (dexReceipts.Count > 0)
+            {
+                receipts ??= new List<TransactionReceipt>();
+                receipts.AddRange(dexReceipts);
+            }
+        }
+
+        return receipts;
+    }
+
+    /// <summary>
+    /// Apply a single finalized block to canonical state. Used by consensus finalization path.
+    /// Executes transactions, adds to chain, prunes mempool, persists, checks epochs, broadcasts.
+    /// </summary>
+    /// <returns>Result indicating success/failure.</returns>
+    public BlockApplyResult ApplyBlock(Block block, IStateDatabase stateDb,
+        byte[] rawBlockData, ulong commitBitmap = 0)
+    {
+        // Execute transactions + DEX settlement
+        var receipts = ExecuteBlock(block, stateDb);
+        if (receipts != null)
+            block.Receipts = receipts;
+
+        // Add to chain
+        var result = _chainManager.AddBlock(block);
+        if (!result.IsSuccess)
+        {
+            return new BlockApplyResult { Success = false, Error = result.Message };
+        }
+
+        // Prune mempool
+        _mempool.RemoveConfirmed(block.Transactions);
+        var pruned = _mempool.PruneStale(stateDb, block.Header.BaseFee);
+        if (pruned > 0)
+            _logger.LogInformation("Pruned {Count} unexecutable transactions from mempool", pruned);
+        _mempool.UpdateBaseFee(block.Header.BaseFee);
+
+        // Prometheus metrics
+        MetricsEndpoint.RecordBlock(block.Transactions.Count, block.Header.Timestamp);
+        MetricsEndpoint.RecordBaseFee(block.Header.BaseFee.IsZero ? 0 : (long)(ulong)block.Header.BaseFee);
+        MetricsEndpoint.RecordConsensusView((long)block.Number);
+        MetricsEndpoint.RecordDexIntentCount(_mempool.DexIntentCount);
+
+        // WebSocket broadcast
+        _ = _wsHandler.BroadcastNewBlock(block);
+
+        // Persist block + receipts
+        PersistBlock(block, rawBlockData, commitBitmap);
+        PersistReceipts(block.Receipts);
+
+        // Record commit participation
+        _epochManager?.RecordBlockSigners(block.Number, commitBitmap);
+
+        // Check epoch transition
+        var newSet = _epochManager?.OnBlockFinalized(block.Number);
+        if (newSet != null)
+        {
+            ApplyEpochTransition(newSet, block.Number);
+        }
+
+        return new BlockApplyResult
+        {
+            Success = true,
+            Receipts = block.Receipts,
+        };
+    }
+
+    /// <summary>
+    /// Apply a batch of blocks on a forked state database, then atomically swap canonical state.
+    /// Used by sync paths (P2P sync and RPC HTTP sync).
+    /// </summary>
+    /// <param name="blocks">Ordered list of (Block, RawBytes, CommitBitmap) tuples.</param>
+    /// <param name="stateDbRef">The shared state reference to fork and swap.</param>
+    /// <returns>Number of blocks successfully applied.</returns>
+    public int ApplyBatch(IReadOnlyList<(Block Block, byte[] Raw, ulong CommitBitmap)> blocks,
+        StateDbRef stateDbRef)
+    {
+        if (blocks.Count == 0)
+            return 0;
+
+        var forkedState = stateDbRef.Fork();
+        var applied = 0;
+
+        // Phase 1: Execute all blocks on forked state
+        foreach (var (block, raw, bitmap) in blocks)
+        {
+            try
+            {
+                var receipts = ExecuteBlock(block, forkedState);
+                if (receipts != null)
+                    block.Receipts = receipts;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to execute synced block #{Number}", block.Number);
+                break;
+            }
+        }
+
+        // Phase 2: Add executed blocks to chain and persist
+        foreach (var (block, raw, bitmap) in blocks)
+        {
+            if (block.Receipts == null && block.Transactions.Count > 0)
+                break; // This block wasn't executed (failed in phase 1)
+
+            var result = _chainManager.AddBlock(block);
+            if (!result.IsSuccess)
+            {
+                _logger.LogWarning("Failed to apply synced block #{Number}: {Error}",
+                    block.Number, result.Message);
+                break;
+            }
+
+            _mempool.RemoveConfirmed(block.Transactions);
+            PersistBlock(block, raw, bitmap);
+            PersistReceipts(block.Receipts);
+            applied++;
+
+            _epochManager?.RecordBlockSigners(block.Number, bitmap);
+
+            var newSet = _epochManager?.OnBlockFinalized(block.Number);
+            if (newSet != null)
+                ApplyEpochTransition(newSet, block.Number);
+        }
+
+        // Phase 3: Atomically swap state only if ALL blocks succeeded
+        if (applied == blocks.Count && applied > 0)
+        {
+            stateDbRef.Swap(forkedState);
+            _logger.LogInformation("Synced {Count} blocks, now at #{Height}",
+                applied, _chainManager.LatestBlockNumber);
+        }
+        else if (applied > 0)
+        {
+            _logger.LogWarning(
+                "Partial sync: applied {Applied}/{Total} blocks — state not adopted",
+                applied, blocks.Count);
+        }
+
+        // Prune mempool after sync with current base fee
+        var latestBlock = _chainManager.LatestBlock;
+        if (latestBlock != null && applied > 0)
+        {
+            var pruned = _mempool.PruneStale(stateDbRef, latestBlock.Header.BaseFee);
+            if (pruned > 0)
+                _logger.LogInformation("Pruned {Count} unexecutable transactions from mempool after sync", pruned);
+            _mempool.UpdateBaseFee(latestBlock.Header.BaseFee);
+        }
+
+        return applied;
+    }
+
+    private void ApplyEpochTransition(ValidatorSet newSet, ulong blockNumber)
+    {
+        // Flush staking state
+        if (_stakingPersistence != null && _stakingState != null)
+        {
+            try
+            {
+                _stakingState.FlushToPersistence(_stakingPersistence);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to flush staking state after epoch transition");
+            }
+        }
+
+        _logger.LogInformation(
+            "Epoch transition at block #{Block}: {NewCount} validators, quorum: {Quorum}",
+            blockNumber, newSet.Count, newSet.QuorumThreshold);
+
+        // Notify caller (NodeCoordinator) to rewire consensus-specific components
+        OnEpochTransition?.Invoke(newSet, blockNumber);
+    }
+
+    private void PersistBlock(Block block, byte[] serializedBlockData, ulong? commitBitmap = null)
+    {
+        if (_blockStore == null)
+            return;
+
+        try
+        {
+            var blockData = new BlockData
+            {
+                Number = block.Number,
+                Hash = block.Hash,
+                ParentHash = block.Header.ParentHash,
+                StateRoot = block.Header.StateRoot,
+                TransactionsRoot = block.Header.TransactionsRoot,
+                ReceiptsRoot = block.Header.ReceiptsRoot,
+                Timestamp = block.Header.Timestamp,
+                Proposer = block.Header.Proposer,
+                ChainId = block.Header.ChainId,
+                GasUsed = block.Header.GasUsed,
+                GasLimit = block.Header.GasLimit,
+                BaseFee = block.Header.BaseFee,
+                ProtocolVersion = block.Header.ProtocolVersion,
+                ExtraData = block.Header.ExtraData,
+                TransactionHashes = block.Transactions.Select(t => t.Hash).ToArray(),
+            };
+            _blockStore.PutFullBlock(blockData, serializedBlockData, commitBitmap);
+            _blockStore.SetLatestBlockNumber(block.Number);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to persist block #{Number}", block.Number);
+        }
+    }
+
+    private void PersistReceipts(List<TransactionReceipt>? receipts)
+    {
+        if (_receiptStore == null || receipts == null || receipts.Count == 0)
+            return;
+
+        try
+        {
+            var receiptDataList = receipts.Select(r => new ReceiptData
+            {
+                TransactionHash = r.TransactionHash,
+                BlockHash = r.BlockHash,
+                BlockNumber = r.BlockNumber,
+                TransactionIndex = r.TransactionIndex,
+                From = r.From,
+                To = r.To,
+                GasUsed = r.GasUsed,
+                Success = r.Success,
+                ErrorCode = (int)r.ErrorCode,
+                PostStateRoot = r.PostStateRoot,
+                EffectiveGasPrice = r.EffectiveGasPrice,
+                Logs = (r.Logs ?? []).Select(l => new LogData
+                {
+                    Contract = l.Contract,
+                    EventSignature = l.EventSignature,
+                    Topics = l.Topics ?? [],
+                    Data = l.Data ?? [],
+                }).ToArray(),
+            });
+            _receiptStore.PutReceipts(receiptDataList);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to persist {Count} receipts", receipts.Count);
+        }
+    }
+}

--- a/src/node/Basalt.Node/BlockApplier.cs
+++ b/src/node/Basalt.Node/BlockApplier.cs
@@ -244,6 +244,16 @@ public sealed class BlockApplier
                 applied, blocks.Count);
         }
 
+        // WebSocket broadcast + metrics for the latest synced block
+        if (applied > 0)
+        {
+            var lastApplied = blocks[applied - 1].Block;
+            _ = _wsHandler.BroadcastNewBlock(lastApplied);
+            MetricsEndpoint.RecordBlock(lastApplied.Transactions.Count, lastApplied.Header.Timestamp);
+            MetricsEndpoint.RecordBaseFee(lastApplied.Header.BaseFee.IsZero ? 0 : (long)(ulong)lastApplied.Header.BaseFee);
+            MetricsEndpoint.RecordConsensusView((long)lastApplied.Number);
+        }
+
         // Prune mempool after sync with current base fee
         var latestBlock = _chainManager.LatestBlock;
         if (latestBlock != null && applied > 0)

--- a/src/node/Basalt.Node/BlockSyncService.cs
+++ b/src/node/Basalt.Node/BlockSyncService.cs
@@ -1,0 +1,183 @@
+using System.Net.Http.Json;
+using Basalt.Api.Rest;
+using Basalt.Core;
+using Basalt.Execution;
+using Basalt.Network;
+using Basalt.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Basalt.Node;
+
+/// <summary>
+/// Provides sync status for health endpoint reporting.
+/// </summary>
+public interface ISyncStatus
+{
+    /// <summary>How many blocks behind the sync source this node is.</summary>
+    int SyncLag { get; }
+}
+
+/// <summary>
+/// Background service that polls a trusted sync source via HTTP and applies finalized blocks
+/// using <see cref="BlockApplier"/>. Used by RPC nodes that follow the chain without
+/// participating in consensus.
+/// </summary>
+public sealed class BlockSyncService : ISyncStatus, IAsyncDisposable
+{
+    private readonly string _syncSourceUrl;
+    private readonly BlockApplier _blockApplier;
+    private readonly ChainManager _chainManager;
+    private readonly StateDbRef _stateDbRef;
+    private readonly ChainParameters _chainParams;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger _logger;
+
+    private int _syncLag;
+    private int _backoffMs = 1000;
+    private const int MaxBackoffMs = 30_000;
+
+    public int SyncLag => Volatile.Read(ref _syncLag);
+
+    public BlockSyncService(
+        string syncSourceUrl,
+        BlockApplier blockApplier,
+        ChainManager chainManager,
+        StateDbRef stateDbRef,
+        ChainParameters chainParams,
+        ILogger logger)
+    {
+        _syncSourceUrl = syncSourceUrl.TrimEnd('/');
+        _blockApplier = blockApplier;
+        _chainManager = chainManager;
+        _stateDbRef = stateDbRef;
+        _chainParams = chainParams;
+        _logger = logger;
+
+        _httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(_syncSourceUrl),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+    }
+
+    /// <summary>
+    /// Main sync loop. Polls the sync source and applies blocks until cancelled.
+    /// </summary>
+    public async Task RunAsync(CancellationToken ct)
+    {
+        _logger.LogInformation("BlockSyncService started. Source: {Source}", _syncSourceUrl);
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var status = await _httpClient.GetFromJsonAsync(
+                    "/v1/sync/status",
+                    BasaltApiJsonContext.Default.SyncStatusResponse,
+                    ct);
+
+                if (status == null)
+                {
+                    _logger.LogWarning("Sync source returned null status");
+                    await BackoffAsync(ct);
+                    continue;
+                }
+
+                var localTip = _chainManager.LatestBlockNumber;
+                var remoteTip = status.LatestBlock;
+                Volatile.Write(ref _syncLag, (int)Math.Min(remoteTip - localTip, int.MaxValue));
+
+                if (remoteTip <= localTip)
+                {
+                    // Caught up — sleep for one block time, then poll again
+                    _backoffMs = 1000; // Reset backoff
+                    await Task.Delay((int)_chainParams.BlockTimeMs, ct);
+                    continue;
+                }
+
+                // Fetch blocks in batches of 100
+                var from = localTip + 1;
+                var count = (int)Math.Min(remoteTip - localTip, 100);
+
+                var response = await _httpClient.GetFromJsonAsync(
+                    $"/v1/sync/blocks?from={from}&count={count}",
+                    BasaltApiJsonContext.Default.SyncBlocksResponse,
+                    ct);
+
+                if (response?.Blocks == null || response.Blocks.Length == 0)
+                {
+                    _logger.LogDebug("No blocks returned from sync source (from={From})", from);
+                    await BackoffAsync(ct);
+                    continue;
+                }
+
+                // Deserialize and prepare blocks for batch apply
+                var blocks = new List<(Block Block, byte[] Raw, ulong CommitBitmap)>();
+                foreach (var entry in response.Blocks)
+                {
+                    try
+                    {
+                        var raw = Convert.FromHexString(entry.RawHex);
+                        var block = BlockCodec.DeserializeBlock(raw);
+                        blocks.Add((block, raw, entry.CommitBitmap ?? 0));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to deserialize synced block #{Number}", entry.Number);
+                        break;
+                    }
+                }
+
+                if (blocks.Count == 0)
+                {
+                    await BackoffAsync(ct);
+                    continue;
+                }
+
+                var applied = _blockApplier.ApplyBatch(blocks, _stateDbRef);
+                if (applied > 0)
+                {
+                    _backoffMs = 1000; // Reset backoff on success
+                    var newLocalTip = _chainManager.LatestBlockNumber;
+                    Volatile.Write(ref _syncLag, (int)Math.Min(remoteTip - newLocalTip, int.MaxValue));
+
+                    _logger.LogInformation(
+                        "Synced {Count} blocks from source, now at #{Height} (lag: {Lag})",
+                        applied, newLocalTip, SyncLag);
+                }
+                else
+                {
+                    await BackoffAsync(ct);
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning("Sync source unreachable: {Message}", ex.Message);
+                await BackoffAsync(ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error in sync loop");
+                await BackoffAsync(ct);
+            }
+        }
+
+        _logger.LogInformation("BlockSyncService stopped");
+    }
+
+    private async Task BackoffAsync(CancellationToken ct)
+    {
+        await Task.Delay(_backoffMs, ct);
+        _backoffMs = Math.Min(_backoffMs * 2, MaxBackoffMs);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _httpClient.Dispose();
+        await ValueTask.CompletedTask;
+    }
+}

--- a/src/node/Basalt.Node/NodeConfiguration.cs
+++ b/src/node/Basalt.Node/NodeConfiguration.cs
@@ -1,8 +1,17 @@
 namespace Basalt.Node;
 
+public enum NodeMode
+{
+    Standalone,
+    Validator,
+    Rpc,
+}
+
 /// <summary>
 /// Node configuration populated from environment variables:
 /// <list type="bullet">
+/// <item><c>BASALT_MODE</c> — Node mode: auto (default), validator, rpc, standalone</item>
+/// <item><c>BASALT_SYNC_SOURCE</c> — HTTP URL of sync source (required for rpc mode)</item>
 /// <item><c>BASALT_VALIDATOR_INDEX</c> — Validator index (int, -1 = standalone)</item>
 /// <item><c>BASALT_VALIDATOR_ADDRESS</c> — Validator address (hex)</item>
 /// <item><c>BASALT_VALIDATOR_KEY</c> — Ed25519 private key (64 hex chars)</item>
@@ -44,8 +53,37 @@ public sealed class NodeConfiguration
     // Contract sandboxing (opt-in)
     public bool UseSandbox { get; init; }
 
-    // Mode detection
-    public bool IsConsensusMode => Peers.Length > 0 && ValidatorIndex >= 0;
+    // Mode selection
+    public string Mode { get; init; } = "auto";
+    public string? SyncSource { get; init; }
+
+    // Tri-state mode detection
+    public NodeMode ResolvedMode
+    {
+        get
+        {
+            if (string.Equals(Mode, "rpc", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrWhiteSpace(SyncSource))
+                    throw new InvalidOperationException(
+                        "BASALT_MODE=rpc requires BASALT_SYNC_SOURCE to be set (e.g. http://validator-0:5000)");
+                return NodeMode.Rpc;
+            }
+
+            if (string.Equals(Mode, "validator", StringComparison.OrdinalIgnoreCase)
+                || (Peers.Length > 0 && ValidatorIndex >= 0))
+                return NodeMode.Validator;
+
+            if (string.Equals(Mode, "standalone", StringComparison.OrdinalIgnoreCase))
+                return NodeMode.Standalone;
+
+            // auto: fall back to standalone
+            return NodeMode.Standalone;
+        }
+    }
+
+    // Backward-compat alias
+    public bool IsConsensusMode => ResolvedMode == NodeMode.Validator;
 
     public static NodeConfiguration FromEnvironment()
     {
@@ -78,6 +116,9 @@ public sealed class NodeConfiguration
         // N-12: Validate DataDir to prevent path traversal
         var validatedDataDir = string.IsNullOrWhiteSpace(dataDir) ? null : ValidateDataDir(dataDir);
 
+        var mode = Environment.GetEnvironmentVariable("BASALT_MODE") ?? "auto";
+        var syncSource = Environment.GetEnvironmentVariable("BASALT_SYNC_SOURCE");
+
         return new NodeConfiguration
         {
             ValidatorIndex = validatorIndex,
@@ -91,6 +132,8 @@ public sealed class NodeConfiguration
             DataDir = validatedDataDir,
             UsePipelining = usePipelining,
             UseSandbox = useSandbox,
+            Mode = mode,
+            SyncSource = syncSource,
         };
     }
 

--- a/src/node/Basalt.Node/NodeCoordinator.cs
+++ b/src/node/Basalt.Node/NodeCoordinator.cs
@@ -129,6 +129,8 @@ public sealed class NodeCoordinator : IAsyncDisposable
     private int _consecutiveFinalizationFailures;
     private const int CircuitBreakerThreshold = 5;
     private volatile bool _circuitBreakerTripped;
+    private long _circuitBreakerTrippedAtMs;
+    private const long CircuitBreakerCooldownMs = 30_000; // Auto-reset after 30s
 
     // N-17: Thread-safe double-sign detection: keyed by (view, block, proposer).
     // Block number is included because view numbers can collide across blocks:
@@ -434,7 +436,8 @@ public sealed class NodeCoordinator : IAsyncDisposable
             chainId: _chainParams.ChainId);
 
         // When a block is finalized by consensus, apply it
-        _consensus.OnBlockFinalized += HandleBlockFinalized;
+        // Non-pipelined mode doesn't need the bool return (no _lastFinalizedBlock gap issue)
+        _consensus.OnBlockFinalized += (hash, data, bitmap) => HandleBlockFinalized(hash, data, bitmap);
 
         // When the leader builds an aggregate QC, broadcast to all peers
         _consensus.OnAggregateVote += aggregate =>
@@ -473,8 +476,9 @@ public sealed class NodeCoordinator : IAsyncDisposable
             _chainParams.ChainId,
             TimeSpan.FromMilliseconds(_chainParams.ConsensusTimeoutMs));
 
-        // When a block is finalized by pipelined consensus, apply it
-        _pipelinedConsensus.OnBlockFinalized += HandleBlockFinalized;
+        // When a block is finalized by pipelined consensus, apply it.
+        // Returns bool so _lastFinalizedBlock only advances on success.
+        _pipelinedConsensus.OnBlockFinalized = HandleBlockFinalized;
 
         _pipelinedConsensus.OnViewChange += (view) =>
         {
@@ -492,7 +496,7 @@ public sealed class NodeCoordinator : IAsyncDisposable
         _logger.LogInformation("Consensus: pipelined mode (PipelinedConsensus)");
     }
 
-    private void HandleBlockFinalized(Hash256 hash, byte[] blockData, ulong commitBitmap)
+    private bool HandleBlockFinalized(Hash256 hash, byte[] blockData, ulong commitBitmap)
     {
         try
         {
@@ -513,7 +517,7 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 {
                     _logger.LogError("Block #{Num} rejected: timestamp {BlockTs} before parent {ParentTs}",
                         block.Number, block.Header.Timestamp, parentBlock.Header.Timestamp);
-                    return; // Skip finalization
+                    return false;
                 }
                 var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 var maxDrift = (long)_chainParams.BlockTimeMs * 15; // 15 blocks of drift allowed (~30s at 2s blocks)
@@ -521,7 +525,7 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 {
                     _logger.LogError("Block #{Num} rejected: timestamp {Ahead}ms ahead of local time (max drift: {MaxDrift}ms)",
                         block.Number, block.Header.Timestamp - now, maxDrift);
-                    return; // Skip finalization
+                    return false;
                 }
             }
 
@@ -570,6 +574,8 @@ public sealed class NodeCoordinator : IAsyncDisposable
 
                 // In pipelined mode, cleanup finalized rounds
                 _pipelinedConsensus?.CleanupFinalizedRounds();
+
+                return true;
             }
             else
             {
@@ -581,8 +587,10 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 if (failures >= CircuitBreakerThreshold && !_circuitBreakerTripped)
                 {
                     _circuitBreakerTripped = true;
+                    Volatile.Write(ref _circuitBreakerTrippedAtMs, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                     _logger.LogCritical(
-                        "CIRCUIT BREAKER: {Failures} consecutive finalization failures. Halting proposals.", failures);
+                        "CIRCUIT BREAKER: {Failures} consecutive finalization failures. Halting proposals for {Cooldown}s.",
+                        failures, CircuitBreakerCooldownMs / 1000);
                 }
 
                 // If we're behind (block number > our tip + 1), trigger a sync
@@ -593,11 +601,14 @@ public sealed class NodeCoordinator : IAsyncDisposable
                         _chainManager.LatestBlockNumber, block.Number);
                     _ = Task.Run(() => TrySyncFromPeers(_cts?.Token ?? CancellationToken.None));
                 }
+
+                return false;
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error applying finalized block");
+            return false;
         }
     }
 
@@ -1548,8 +1559,32 @@ public sealed class NodeCoordinator : IAsyncDisposable
         // Wait for peers to connect
         await Task.Delay(2000, ct);
 
-        // Check if we need to sync before joining consensus
-        await TrySyncFromPeers(ct);
+        // Retry initial sync until caught up or no peers are ahead.
+        // A single sync attempt can fail mid-way due to peer disconnects.
+        // Without retry, the node would enter consensus far behind and rely
+        // solely on OnBehindDetected (which requires receiving proposals).
+        for (int attempt = 0; attempt < 10; attempt++)
+        {
+            var heightBefore = _chainManager.LatestBlockNumber;
+            await TrySyncFromPeers(ct);
+            var heightAfter = _chainManager.LatestBlockNumber;
+
+            // If we didn't make progress, we're either caught up or peers are unreachable
+            if (heightAfter <= heightBefore)
+                break;
+
+            // Check if there's still a gap to close
+            var bestPeer = GetBestPeer();
+            if (bestPeer == null || bestPeer.BestBlockNumber <= heightAfter)
+                break;
+
+            _logger.LogInformation(
+                "Initial sync interrupted at #{Height} (peer at #{Peer}), retrying... (attempt {Attempt})",
+                heightAfter, bestPeer.BestBlockNumber, attempt + 2);
+
+            // Brief pause to allow reconnection if peer dropped
+            await Task.Delay(1000, ct);
+        }
 
         if (_config.UsePipelining)
         {
@@ -1613,6 +1648,32 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 if (Volatile.Read(ref _isSyncing) != 0)
                     continue;
 
+                // Circuit breaker auto-reset: after cooldown, reset and attempt
+                // sync to recover from transient failures (state divergence, etc.)
+                if (_circuitBreakerTripped)
+                {
+                    var trippedAt = Volatile.Read(ref _circuitBreakerTrippedAtMs);
+                    var elapsed = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - trippedAt;
+                    if (elapsed >= CircuitBreakerCooldownMs)
+                    {
+                        _logger.LogWarning(
+                            "Circuit breaker cooldown expired ({Elapsed}ms). Resetting and attempting sync recovery.",
+                            elapsed);
+                        _circuitBreakerTripped = false;
+                        Interlocked.Exchange(ref _consecutiveFinalizationFailures, 0);
+
+                        // Re-sync consensus state to match the actual chain
+                        _pipelinedConsensus!.UpdateLastFinalizedBlock(_chainManager.LatestBlockNumber);
+
+                        // Attempt to sync from peers in case we fell behind
+                        _ = Task.Run(() => TrySyncFromPeers(ct), ct);
+                    }
+                    else
+                    {
+                        continue; // Still in cooldown, skip this iteration
+                    }
+                }
+
                 // In pipelined mode, try to propose next block if pipeline has capacity
                 TryProposeBlock();
 
@@ -1628,6 +1689,19 @@ public sealed class NodeCoordinator : IAsyncDisposable
 
                 // Cleanup finalized rounds periodically
                 _pipelinedConsensus.CleanupFinalizedRounds();
+
+                // Periodic behind-detection: check if any connected peer is significantly
+                // ahead. This catches the case where a node fell behind and no proposals
+                // arrive (e.g., because other validators' circuit breakers are also tripped).
+                // Without this, OnBehindDetected only fires from received proposals.
+                var bestPeerCheck = GetBestPeer();
+                if (bestPeerCheck != null && bestPeerCheck.BestBlockNumber > _chainManager.LatestBlockNumber + 10)
+                {
+                    _logger.LogInformation(
+                        "Peer {Peer} is at #{PeerHeight} vs local #{LocalHeight} — triggering catch-up sync",
+                        bestPeerCheck.Id, bestPeerCheck.BestBlockNumber, _chainManager.LatestBlockNumber);
+                    _ = Task.Run(() => TrySyncFromPeers(ct), ct);
+                }
 
                 _episub!.RebalanceTiers();
             }

--- a/src/node/Basalt.Node/NodeCoordinator.cs
+++ b/src/node/Basalt.Node/NodeCoordinator.cs
@@ -85,6 +85,7 @@ public sealed class NodeCoordinator : IAsyncDisposable
     // Block production (consensus-driven — no BlockProductionLoop)
     private BlockBuilder? _blockBuilder;
     private TransactionExecutor? _txExecutor;
+    private BlockApplier? _blockApplier;
     private Address _proposerAddress;
 
     // Solver network (Phase E4)
@@ -94,6 +95,11 @@ public sealed class NodeCoordinator : IAsyncDisposable
     /// Exposes the solver manager for wiring into the REST API adapter.
     /// </summary>
     public Solver.SolverManager? SolverManager => _solverManager;
+
+    /// <summary>
+    /// Exposes the block applier for reuse by other components (e.g., BlockSyncService in RPC mode).
+    /// </summary>
+    public BlockApplier? BlockApplier => _blockApplier;
 
     // Runtime
     private CancellationTokenSource? _cts;
@@ -519,43 +525,12 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 }
             }
 
-            // All validators execute finalized transactions against canonical state.
-            // Proposals use a forked state, so the leader's live state is never speculatively mutated.
-            if (block.Transactions.Count > 0)
+            // Apply block via shared BlockApplier (executes txs, DEX settlement, chain update,
+            // mempool pruning, persistence, epoch transitions, WebSocket broadcast, metrics).
+            var applyResult = _blockApplier!.ApplyBlock(block, _stateDb, blockData, commitBitmap);
+
+            if (applyResult.Success)
             {
-                var receipts = new List<TransactionReceipt>(block.Transactions.Count);
-                for (int i = 0; i < block.Transactions.Count; i++)
-                {
-                    var receipt = _txExecutor!.Execute(block.Transactions[i], _stateDb, block.Header, i);
-                    receipts.Add(receipt);
-                }
-                block.Receipts = receipts;
-            }
-
-            // Run DEX settlement on canonical state (TWAP carry-forward + limit order matching)
-            if (_blockBuilder != null)
-            {
-                var dexReceipts = _blockBuilder.ApplyDexSettlement(_stateDb, block.Header);
-                if (dexReceipts.Count > 0)
-                {
-                    block.Receipts ??= new List<TransactionReceipt>();
-                    block.Receipts.AddRange(dexReceipts);
-                }
-            }
-
-            var result = _chainManager.AddBlock(block);
-            if (result.IsSuccess)
-            {
-                _mempool.RemoveConfirmed(block.Transactions);
-
-                // Prune stale, underpriced, or unaffordable transactions
-                var pruned = _mempool.PruneStale(_stateDb, block.Header.BaseFee);
-                if (pruned > 0)
-                    _logger.LogInformation("Pruned {Count} unexecutable transactions from mempool", pruned);
-
-                // Update mempool admission gate so new submissions below the current base fee are rejected early
-                _mempool.UpdateBaseFee(block.Header.BaseFee);
-
                 // Circuit breaker: reset on success
                 Interlocked.Exchange(ref _consecutiveFinalizationFailures, 0);
                 if (_circuitBreakerTripped)
@@ -564,24 +539,16 @@ public sealed class NodeCoordinator : IAsyncDisposable
                     _logger.LogWarning("Circuit breaker reset after successful block finalization");
                 }
 
-                MetricsEndpoint.RecordBlock(block.Transactions.Count, block.Header.Timestamp);
-
-                // M13: Record additional Prometheus metrics
+                // M13: Additional consensus-specific metrics
                 var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 var prevFinalizedMs = Volatile.Read(ref _lastBlockFinalizedAtMs);
                 if (prevFinalizedMs > 0)
                     MetricsEndpoint.RecordFinalizationLatency(nowMs - prevFinalizedMs);
-                MetricsEndpoint.RecordBaseFee(block.Header.BaseFee.IsZero ? 0 : (long)(ulong)block.Header.BaseFee);
-                MetricsEndpoint.RecordConsensusView((long)block.Number);
                 MetricsEndpoint.RecordPeerCount(_peerManager?.ConnectedCount ?? 0);
-                MetricsEndpoint.RecordDexIntentCount(_mempool.DexIntentCount);
-
-                _ = _wsHandler.BroadcastNewBlock(block);
 
                 Volatile.Write(ref _lastBlockFinalizedAtMs, nowMs);
 
-                // N-10: Sliding window — retain evidence for last 10 views instead of clearing entirely.
-                // This preserves recent evidence for double-sign detection while preventing unbounded growth.
+                // N-10: Sliding window — retain evidence for last 10 views
                 {
                     var currentView = block.Number;
                     var cutoff = currentView > 10 ? currentView - 10 : 0;
@@ -590,22 +557,8 @@ public sealed class NodeCoordinator : IAsyncDisposable
                         _proposalsByView.TryRemove(key, out _);
                 }
 
-                // Announce finalized block to peers so their BestBlockNumber stays
-                // current.  Without this, TrySyncFromPeers can't find an up-to-date
-                // peer and validators that fall behind are unable to catch up.
+                // Announce finalized block to peers
                 _gossip!.BroadcastBlock(block.Number, block.Hash, block.Header.ParentHash);
-
-                // Persist block + commit bitmap atomically to RocksDB
-                PersistBlock(block, blockData, commitBitmap);
-                PersistReceipts(block.Receipts);
-
-                // Record commit participation for deterministic epoch-boundary slashing
-                _epochManager?.RecordBlockSigners(block.Number, commitBitmap);
-
-                // Check for epoch transition — rebuild validator set if at boundary
-                var newSet = _epochManager?.OnBlockFinalized(block.Number);
-                if (newSet != null)
-                    ApplyEpochTransition(newSet, block.Number);
 
                 _logger.LogInformation(
                     "Block #{Number} finalized via consensus. Hash: {Hash}, Txs: {TxCount}",
@@ -621,7 +574,7 @@ public sealed class NodeCoordinator : IAsyncDisposable
             else
             {
                 _logger.LogError("Failed to add consensus-finalized block #{Number}: {Error}",
-                    block.Number, result.Message);
+                    block.Number, applyResult.Error);
 
                 // Circuit breaker: increment failure count
                 var failures = Interlocked.Increment(ref _consecutiveFinalizationFailures);
@@ -633,7 +586,6 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 }
 
                 // If we're behind (block number > our tip + 1), trigger a sync
-                // to catch up on missed blocks before the next round.
                 if (block.Number > _chainManager.LatestBlockNumber + 1)
                 {
                     _logger.LogWarning(
@@ -677,6 +629,36 @@ public sealed class NodeCoordinator : IAsyncDisposable
             _solverManager.GetBestSettlement(
                 poolId, buys, sells, reserves, feeBps,
                 intentMinAmounts, stateDb, dexState, intentTxMap);
+
+        // Create shared BlockApplier for finalization and sync paths
+        _blockApplier = new BlockApplier(
+            _chainParams, _chainManager, _mempool, _txExecutor, _blockBuilder,
+            _blockStore, _receiptStore, _epochManager, _stakingState, _stakingPersistence,
+            _wsHandler, _loggerFactory.CreateLogger<BlockApplier>());
+
+        // Hook epoch transitions to rewire consensus-specific components
+        _blockApplier.OnEpochTransition += (newSet, blockNumber) =>
+        {
+            var oldCount = _validatorSet?.Count ?? 0;
+            _validatorSet = newSet;
+
+            if (_stakingState != null)
+            {
+                _leaderSelector = new WeightedLeaderSelector(_validatorSet);
+                _validatorSet.SetLeaderSelector(view => _leaderSelector.SelectLeader(view));
+            }
+
+            if (_config.UsePipelining)
+                _pipelinedConsensus?.UpdateValidatorSet(newSet);
+            else
+                _consensus?.UpdateValidatorSet(newSet);
+
+            // N-10: Sliding window — retain evidence for last 10 views on epoch transition
+            var cutoff = blockNumber > 10 ? blockNumber - 10 : 0;
+            var oldKeys = _proposalsByView.Keys.ToArray().Where(k => k.View < cutoff).ToList();
+            foreach (var key in oldKeys)
+                _proposalsByView.TryRemove(key, out _);
+        };
 
         if (_config.UseSandbox)
             _logger.LogInformation("Contract execution: sandboxed mode (AssemblyLoadContext isolation)");
@@ -1214,36 +1196,11 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 if (block.Number != _chainManager.LatestBlockNumber + 1)
                     continue;
 
-                // Execute transactions and capture receipts
-                if (block.Transactions.Count > 0)
-                {
-                    var receipts = new List<TransactionReceipt>(block.Transactions.Count);
-                    for (int i = 0; i < block.Transactions.Count; i++)
-                    {
-                        var receipt = _txExecutor!.Execute(block.Transactions[i], _stateDb, block.Header, i);
-                        receipts.Add(receipt);
-                    }
-                    block.Receipts = receipts;
-                }
+                var bitmap = idx < payload.CommitBitmaps.Length ? payload.CommitBitmaps[idx] : 0UL;
+                var result = _blockApplier!.ApplyBlock(block, _stateDb, blockBytes, bitmap);
 
-                var result = _chainManager.AddBlock(block);
-                if (result.IsSuccess)
-                {
-                    _mempool.RemoveConfirmed(block.Transactions);
-                    var bitmap = idx < payload.CommitBitmaps.Length ? payload.CommitBitmaps[idx] : 0UL;
-                    PersistBlock(block, blockBytes, bitmap);
-                    PersistReceipts(block.Receipts);
-
-                    // Use propagated commit bitmap from the serving peer
-                    _epochManager?.RecordBlockSigners(block.Number, bitmap);
-
-                    // Apply epoch transitions for blocks received via gossip
-                    var newSet = _epochManager?.OnBlockFinalized(block.Number);
-                    if (newSet != null)
-                        ApplyEpochTransition(newSet, block.Number);
-
+                if (result.Success)
                     _logger.LogInformation("Applied block #{Number} from peer", block.Number);
-                }
             }
             catch (Exception ex)
             {
@@ -1316,12 +1273,8 @@ public sealed class NodeCoordinator : IAsyncDisposable
 
     private void HandleSyncResponse(PeerId sender, SyncResponseMessage response)
     {
-        var applied = 0;
-
-        // N-05: Fork state for sync — execute all blocks on a forked state database.
-        // Only replace canonical state if all blocks in the batch succeed.
-        var forkedState = _stateDb.Fork();
-        var blocksToApply = new List<(Block Block, byte[] Raw, int OrigIdx)>();
+        // Deserialize and validate block sequence
+        var blocksToApply = new List<(Block Block, byte[] Raw, ulong CommitBitmap)>();
 
         for (int idx = 0; idx < response.Blocks.Length; idx++)
         {
@@ -1337,82 +1290,18 @@ public sealed class NodeCoordinator : IAsyncDisposable
                     continue;
                 }
 
-                // Execute transactions against the forked state
-                if (block.Transactions.Count > 0)
-                {
-                    var receipts = new List<TransactionReceipt>(block.Transactions.Count);
-                    for (int i = 0; i < block.Transactions.Count; i++)
-                    {
-                        var receipt = _txExecutor!.Execute(block.Transactions[i], forkedState, block.Header, i);
-                        receipts.Add(receipt);
-                    }
-                    block.Receipts = receipts;
-                }
-
-                // Run DEX settlement on forked state (TWAP carry-forward + limit order matching)
-                if (_blockBuilder != null)
-                {
-                    var dexReceipts = _blockBuilder.ApplyDexSettlement(forkedState, block.Header);
-                    if (dexReceipts.Count > 0)
-                    {
-                        block.Receipts ??= new List<TransactionReceipt>();
-                        block.Receipts.AddRange(dexReceipts);
-                    }
-                }
-
-                blocksToApply.Add((block, blockBytes, idx));
+                var bitmap = idx < response.CommitBitmaps.Length ? response.CommitBitmaps[idx] : 0UL;
+                blocksToApply.Add((block, blockBytes, bitmap));
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to process synced block from {Sender}", sender);
+                _logger.LogWarning(ex, "Failed to deserialize synced block from {Sender}", sender);
                 break;
             }
         }
 
-        // Apply all successfully executed blocks to the chain
-        foreach (var (block, blockBytes, origIdx) in blocksToApply)
-        {
-            var result = _chainManager.AddBlock(block);
-            if (result.IsSuccess)
-            {
-                _mempool.RemoveConfirmed(block.Transactions);
-                var bitmap = origIdx < response.CommitBitmaps.Length ? response.CommitBitmaps[origIdx] : 0UL;
-                PersistBlock(block, blockBytes, bitmap);
-                PersistReceipts(block.Receipts);
-                applied++;
-
-                // Use propagated commit bitmap from the serving peer
-                _epochManager?.RecordBlockSigners(block.Number, bitmap);
-
-                // Apply epoch transitions for synced blocks — without this,
-                // nodes that sync across epoch boundaries would have a stale
-                // ValidatorSet and disagree on leader selection.
-                var newSet = _epochManager?.OnBlockFinalized(block.Number);
-                if (newSet != null)
-                    ApplyEpochTransition(newSet, block.Number);
-            }
-            else
-            {
-                _logger.LogWarning("Failed to apply synced block #{Number}: {Error}", block.Number, result.Message);
-                break;
-            }
-        }
-
-        // N-05: Only adopt the forked state if all blocks were applied successfully.
-        // Swap() updates the shared StateDbRef so the API layer sees the new state.
-        if (applied == blocksToApply.Count && applied > 0)
-        {
-            _stateDb.Swap(forkedState);
-            _logger.LogInformation("Synced {Count} blocks, now at #{Height}", applied, _chainManager.LatestBlockNumber);
-        }
-        else if (applied > 0)
-        {
-            // HIGH-04: Partial sync — blocks were added to ChainManager but state was not
-            // adopted. Roll back ChainManager to the last consistent block to prevent
-            // chain/state divergence. The next sync attempt will re-fetch these blocks.
-            _logger.LogWarning("Partial sync: applied {Applied}/{Total} blocks — rolling back chain to consistent state",
-                applied, blocksToApply.Count);
-        }
+        // Delegate to BlockApplier for fork-execute-swap
+        var applied = _blockApplier!.ApplyBatch(blocksToApply, _stateDb);
 
         // Signal the sync loop under lock to prevent stale responses completing wrong TCS
         lock (this)
@@ -1891,121 +1780,9 @@ public sealed class NodeCoordinator : IAsyncDisposable
         return best;
     }
 
-    /// <summary>
-    /// Apply an epoch transition: swap the validator set, rewire consensus and leader selection.
-    /// </summary>
-    private void ApplyEpochTransition(ValidatorSet newSet, ulong blockNumber)
-    {
-        var oldCount = _validatorSet?.Count ?? 0;
-        _validatorSet = newSet;
-
-        // Rewire leader selector with new set (reads snapshotted stakes from ValidatorInfo.Stake)
-        if (_stakingState != null)
-        {
-            _leaderSelector = new WeightedLeaderSelector(_validatorSet);
-            _validatorSet.SetLeaderSelector(view => _leaderSelector.SelectLeader(view));
-        }
-
-        // Update consensus engine
-        if (_config.UsePipelining)
-            _pipelinedConsensus?.UpdateValidatorSet(newSet);
-        else
-            _consensus?.UpdateValidatorSet(newSet);
-
-        // N-10: Sliding window — retain evidence for last 10 views on epoch transition
-        {
-            var cutoff = blockNumber > 10 ? blockNumber - 10 : 0;
-            var oldKeys = _proposalsByView.Keys.ToArray().Where(k => k.View < cutoff).ToList();
-            foreach (var key in oldKeys)
-                _proposalsByView.TryRemove(key, out _);
-        }
-
-        // B1: Flush staking state after epoch transition
-        if (_stakingPersistence != null && _stakingState != null)
-        {
-            try
-            {
-                _stakingState.FlushToPersistence(_stakingPersistence);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to flush staking state after epoch transition");
-            }
-        }
-
-        _logger.LogInformation("Epoch transition at block #{Block}: {OldCount} → {NewCount} validators, quorum: {Quorum}",
-            blockNumber, oldCount, newSet.Count, newSet.QuorumThreshold);
-    }
-
-    private void PersistBlock(Block block, byte[] serializedBlockData, ulong? commitBitmap = null)
-    {
-        if (_blockStore == null)
-            return;
-
-        try
-        {
-            var blockData = new BlockData
-            {
-                Number = block.Number,
-                Hash = block.Hash,
-                ParentHash = block.Header.ParentHash,
-                StateRoot = block.Header.StateRoot,
-                TransactionsRoot = block.Header.TransactionsRoot,
-                ReceiptsRoot = block.Header.ReceiptsRoot,
-                Timestamp = block.Header.Timestamp,
-                Proposer = block.Header.Proposer,
-                ChainId = block.Header.ChainId,
-                GasUsed = block.Header.GasUsed,
-                GasLimit = block.Header.GasLimit,
-                BaseFee = block.Header.BaseFee,
-                ProtocolVersion = block.Header.ProtocolVersion,
-                ExtraData = block.Header.ExtraData,
-                TransactionHashes = block.Transactions.Select(t => t.Hash).ToArray(),
-            };
-            _blockStore.PutFullBlock(blockData, serializedBlockData, commitBitmap);
-            _blockStore.SetLatestBlockNumber(block.Number);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to persist block #{Number}", block.Number);
-        }
-    }
-
-    private void PersistReceipts(List<TransactionReceipt>? receipts)
-    {
-        if (_receiptStore == null || receipts == null || receipts.Count == 0)
-            return;
-
-        try
-        {
-            var receiptDataList = receipts.Select(r => new ReceiptData
-            {
-                TransactionHash = r.TransactionHash,
-                BlockHash = r.BlockHash,
-                BlockNumber = r.BlockNumber,
-                TransactionIndex = r.TransactionIndex,
-                From = r.From,
-                To = r.To,
-                GasUsed = r.GasUsed,
-                Success = r.Success,
-                ErrorCode = (int)r.ErrorCode,
-                PostStateRoot = r.PostStateRoot,
-                EffectiveGasPrice = r.EffectiveGasPrice,
-                Logs = (r.Logs ?? []).Select(l => new LogData
-                {
-                    Contract = l.Contract,
-                    EventSignature = l.EventSignature,
-                    Topics = l.Topics ?? [],
-                    Data = l.Data ?? [],
-                }).ToArray(),
-            });
-            _receiptStore.PutReceipts(receiptDataList);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to persist {Count} receipts", receipts.Count);
-        }
-    }
+    // PersistBlock, PersistReceipts, and ApplyEpochTransition logic is now in BlockApplier.
+    // Consensus-specific epoch rewiring (leader selector, consensus engine, proposal cache)
+    // is handled via the BlockApplier.OnEpochTransition event, wired in SetupBlockProduction().
 
     public async ValueTask DisposeAsync()
     {

--- a/src/node/Basalt.Node/NodeCoordinator.cs
+++ b/src/node/Basalt.Node/NodeCoordinator.cs
@@ -38,6 +38,7 @@ public sealed class NodeCoordinator : IAsyncDisposable
     // Persistent storage (optional — null when using in-memory)
     private readonly BlockStore? _blockStore;
     private readonly ReceiptStore? _receiptStore;
+    private readonly RocksDbStore? _rocksDbStore;
 
     // Staking / Slashing
     private readonly StakingState? _stakingState;
@@ -132,6 +133,11 @@ public sealed class NodeCoordinator : IAsyncDisposable
     private long _circuitBreakerTrippedAtMs;
     private const long CircuitBreakerCooldownMs = 30_000; // Auto-reset after 30s
 
+    // Fork detection: binary search for fork point
+    private (ulong RequestedBlock, TaskCompletionSource<(Hash256 Hash, bool HasBlock)> Tcs)? _forkHashPending;
+    private const int MaxRollbackDepth = 1000;
+    private const int MaxForkRetries = 3;
+
     // N-17: Thread-safe double-sign detection: keyed by (view, block, proposer).
     // Block number is included because view numbers can collide across blocks:
     // after a view change bumps view to V, and then StartRound(V) reuses the same
@@ -159,7 +165,8 @@ public sealed class NodeCoordinator : IAsyncDisposable
         StakingState? stakingState = null,
         SlashingEngine? slashingEngine = null,
         IComplianceVerifier? complianceVerifier = null,
-        Basalt.Consensus.Staking.IStakingPersistence? stakingPersistence = null)
+        Basalt.Consensus.Staking.IStakingPersistence? stakingPersistence = null,
+        RocksDbStore? rocksDbStore = null)
     {
         // MEDIUM-01: Validate chain parameters at startup to catch misconfigurations early.
         chainParams.Validate();
@@ -179,6 +186,7 @@ public sealed class NodeCoordinator : IAsyncDisposable
         _slashingEngine = slashingEngine;
         _complianceVerifier = complianceVerifier;
         _stakingPersistence = stakingPersistence;
+        _rocksDbStore = rocksDbStore;
     }
 
     public async Task StartAsync(CancellationToken ct = default)
@@ -1009,6 +1017,14 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 HandleSyncResponse(sender, syncResponse);
                 break;
 
+            case ForkHashRequestMessage forkReq:
+                HandleForkHashRequest(sender, forkReq);
+                break;
+
+            case ForkHashResponseMessage forkResp:
+                HandleForkHashResponse(forkResp);
+                break;
+
             case ConsensusProposalMessage proposal:
                 HandleConsensusProposal(sender, proposal);
                 break;
@@ -1744,6 +1760,7 @@ public sealed class NodeCoordinator : IAsyncDisposable
         try
         {
             var currentBlock = localHeight + 1;
+            var forkRetries = 0;
             while (currentBlock <= peerHeight && !ct.IsCancellationRequested)
             {
                 var batchCount = (int)Math.Min(SyncBatchSize, peerHeight - currentBlock + 1);
@@ -1779,9 +1796,40 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 var madeProgress = await tcs.Task;
                 if (!madeProgress)
                 {
+                    // Attempt fork detection + rollback if we have persistent storage
+                    if (_blockStore != null && forkRetries < MaxForkRetries)
+                    {
+                        var localTip = _chainManager.LatestBlock;
+                        if (localTip != null && peerHeight > localTip.Number)
+                        {
+                            var peerHash = await RequestBlockHash(bestPeer.Id, localTip.Number, ct);
+                            if (peerHash.HasValue && peerHash.Value != localTip.Hash)
+                            {
+                                _logger.LogWarning(
+                                    "Fork detected: peer {Peer} has different hash at block #{Block}",
+                                    bestPeer.Id, localTip.Number);
+
+                                var forkPoint = await FindForkPoint(bestPeer.Id, localTip.Number, ct);
+                                if (forkPoint.HasValue && forkPoint.Value < localTip.Number)
+                                {
+                                    _logger.LogWarning(
+                                        "Fork point at block #{ForkPoint}, rolling back from #{Current}",
+                                        forkPoint.Value, localTip.Number);
+
+                                    if (RollbackToForkPoint(forkPoint.Value))
+                                    {
+                                        forkRetries++;
+                                        currentBlock = _chainManager.LatestBlockNumber + 1;
+                                        continue; // Retry sync from the rolled-back tip
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     _logger.LogWarning(
-                        "Sync stalled at block #{Block} — possible chain fork or invalid blocks from peer {Peer}",
-                        currentBlock, bestPeer.Id);
+                        "Sync stalled at block #{Block} — could not resolve via fork rollback",
+                        currentBlock);
                     break;
                 }
 
@@ -1828,6 +1876,188 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 _logger.LogInformation("Pipelined consensus updated to block #{Block} after sync", _chainManager.LatestBlockNumber);
             }
         }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Fork Detection + Rollback
+    // ════════════════════════════════════════════════════════════════════
+
+    private void HandleForkHashRequest(PeerId sender, ForkHashRequestMessage request)
+    {
+        Hash256 blockHash = Hash256.Zero;
+        bool hasBlock = false;
+
+        var block = _chainManager.GetBlockByNumber(request.BlockNumber);
+        if (block != null)
+        {
+            blockHash = block.Hash;
+            hasBlock = true;
+        }
+        else
+        {
+            var stored = _blockStore?.GetByNumber(request.BlockNumber);
+            if (stored != null)
+            {
+                blockHash = stored.Hash;
+                hasBlock = true;
+            }
+        }
+
+        var response = new ForkHashResponseMessage
+        {
+            SenderId = _localPeerId,
+            Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            BlockNumber = request.BlockNumber,
+            BlockHash = blockHash,
+            HasBlock = hasBlock,
+        };
+        _gossip!.SendToPeer(sender, response);
+    }
+
+    private void HandleForkHashResponse(ForkHashResponseMessage response)
+    {
+        var pending = _forkHashPending;
+        if (pending.HasValue && pending.Value.RequestedBlock == response.BlockNumber)
+        {
+            pending.Value.Tcs.TrySetResult((response.BlockHash, response.HasBlock));
+        }
+    }
+
+    /// <summary>
+    /// Request a block hash at a specific height from a peer.
+    /// Returns null on timeout or if the peer doesn't have the block.
+    /// </summary>
+    private async Task<Hash256?> RequestBlockHash(PeerId peerId, ulong blockNumber, CancellationToken ct)
+    {
+        var tcs = new TaskCompletionSource<(Hash256 Hash, bool HasBlock)>();
+        _forkHashPending = (blockNumber, tcs);
+
+        var request = new ForkHashRequestMessage
+        {
+            SenderId = _localPeerId,
+            Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            BlockNumber = blockNumber,
+        };
+        _gossip!.SendToPeer(peerId, request);
+
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(5000, ct));
+        _forkHashPending = null;
+
+        if (completed != tcs.Task)
+            return null;
+
+        var result = await tcs.Task;
+        return result.HasBlock ? result.Hash : null;
+    }
+
+    /// <summary>
+    /// Get the local block hash at a given height, checking both in-memory and RocksDB.
+    /// </summary>
+    private Hash256? GetLocalBlockHash(ulong blockNumber)
+    {
+        var block = _chainManager.GetBlockByNumber(blockNumber);
+        if (block != null)
+            return block.Hash;
+        return _blockStore?.GetByNumber(blockNumber)?.Hash;
+    }
+
+    /// <summary>
+    /// Binary search for the last block where this node and a peer agree on the hash.
+    /// Returns the fork point block number, or null on failure.
+    /// </summary>
+    private async Task<ulong?> FindForkPoint(PeerId peerId, ulong localHeight, CancellationToken ct)
+    {
+        ulong lo = 0;
+        ulong hi = localHeight;
+
+        while (lo < hi)
+        {
+            ulong mid = lo + (hi - lo + 1) / 2;
+
+            var peerHash = await RequestBlockHash(peerId, mid, ct);
+            if (peerHash == null)
+            {
+                _logger.LogWarning("Fork search: peer did not respond for block #{Block}", mid);
+                return null;
+            }
+
+            var localHash = GetLocalBlockHash(mid);
+            if (localHash == null)
+            {
+                // We don't have this block locally — search lower
+                hi = mid - 1;
+                continue;
+            }
+
+            if (localHash == peerHash)
+                lo = mid; // Hashes match — fork is above
+            else
+                hi = mid - 1; // Hashes differ — fork is at or below
+        }
+
+        return lo;
+    }
+
+    /// <summary>
+    /// Roll back the chain, block store, and state to the given fork point block.
+    /// Returns true if rollback succeeded.
+    /// </summary>
+    private bool RollbackToForkPoint(ulong forkPointBlockNumber)
+    {
+        var currentHeight = _chainManager.LatestBlockNumber;
+        var depth = currentHeight - forkPointBlockNumber;
+
+        if (depth > (ulong)MaxRollbackDepth)
+        {
+            _logger.LogError(
+                "Fork point #{ForkPoint} is {Depth} blocks behind tip #{Tip} — exceeds max rollback depth {Max}",
+                forkPointBlockNumber, depth, currentHeight, MaxRollbackDepth);
+            return false;
+        }
+
+        // 1. Get the fork point block
+        var rawBlock = _blockStore?.GetRawBlockByNumber(forkPointBlockNumber);
+        if (rawBlock == null)
+        {
+            _logger.LogError("Cannot rollback: fork point block #{Block} not found in store", forkPointBlockNumber);
+            return false;
+        }
+
+        var forkPointBlock = BlockCodec.DeserializeBlock(rawBlock);
+        var forkBlockData = _blockStore!.GetByNumber(forkPointBlockNumber);
+        if (forkBlockData == null)
+        {
+            _logger.LogError("Cannot rollback: fork point block data #{Block} not found", forkPointBlockNumber);
+            return false;
+        }
+
+        // 2. Roll back BlockStore (delete blocks after fork point)
+        _blockStore.RollbackToBlock(forkPointBlockNumber, currentHeight);
+        _logger.LogInformation("BlockStore rolled back from #{From} to #{To}", currentHeight, forkPointBlockNumber);
+
+        // 3. Roll back ChainManager
+        _chainManager.RollbackTo(forkPointBlock);
+        _logger.LogInformation("ChainManager rolled back to #{Block}", forkPointBlockNumber);
+
+        // 4. Roll back state — re-root trie to the fork point's state root
+        if (_rocksDbStore != null)
+        {
+            var trieNodeStore = new RocksDbTrieNodeStore(_rocksDbStore);
+            var trie = new TrieStateDb(trieNodeStore, forkBlockData.StateRoot);
+            // Create FlatStateDb with empty cache (no LoadFromPersistence — persistence has stale data).
+            // The trie is the source of truth; cache warms lazily from trie reads.
+            var flat = new FlatStateDb(trie, new RocksDbFlatStatePersistence(_rocksDbStore));
+            _stateDb.Swap(flat);
+            _logger.LogInformation("State rolled back to state root {Root}", forkBlockData.StateRoot.ToHexString()[..18] + "...");
+        }
+
+        // 5. Re-seed epoch manager from the new chain height
+        if (_epochManager != null)
+        {
+            _epochManager.SeedFromChainHeight(forkPointBlockNumber, blockNum => _blockStore.GetCommitBitmap(blockNum));
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/node/Basalt.Node/Program.cs
+++ b/src/node/Basalt.Node/Program.cs
@@ -306,7 +306,9 @@ try
     var contractRuntime = new ManagedContractRuntime();
     var solverInfoAdapter = new Basalt.Node.Solver.SolverInfoAdapter();
     solverInfoAdapter.SetMempool(mempool);
-    RestApiEndpoints.MapBasaltEndpoints(app, chainManager, mempool, validator, stateDbRef, contractRuntime, receiptStore, chainParams: chainParams, solverProvider: solverInfoAdapter);
+    // TxForwarderRef is set later in the RPC branch (mutable wrapper avoids re-registration)
+    var txForwarderRef = new TxForwarderRef();
+    RestApiEndpoints.MapBasaltEndpoints(app, chainManager, mempool, validator, stateDbRef, contractRuntime, receiptStore, chainParams: chainParams, solverProvider: solverInfoAdapter, blockStore: blockStore, txForwarder: txForwarderRef);
 
     // Map faucet endpoint
     var faucetLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Basalt.Faucet");
@@ -322,6 +324,9 @@ try
 
     // Map Prometheus metrics endpoint
     MetricsEndpoint.MapMetricsEndpoint(app, chainManager, mempool);
+
+    // Sync status (set by RPC mode — null for other modes)
+    ISyncStatus? syncStatus = null;
 
     // N-19: Health endpoint with meaningful status info (AOT-safe string formatting)
     ulong lastHealthCheckBlock = 0;
@@ -344,13 +349,31 @@ try
         lastHealthCheckTime = now;
 
         var healthy = makingProgress || (blockAge >= 0 && blockAge < 60);
+
+        // RPC nodes are unhealthy if too far behind the sync source
+        var currentSyncLag = syncStatus?.SyncLag ?? 0;
+        var modeName = config.ResolvedMode switch
+        {
+            NodeMode.Validator => "validator",
+            NodeMode.Rpc => "rpc",
+            _ => "standalone",
+        };
+
+        if (config.ResolvedMode == NodeMode.Rpc && currentSyncLag > 50)
+            healthy = false;
+
         ctx.Response.StatusCode = healthy ? 200 : 503;
         ctx.Response.ContentType = "application/json";
+        var syncLagField = config.ResolvedMode == NodeMode.Rpc
+            ? ",\"syncLag\":" + currentSyncLag
+            : "";
         return ctx.Response.WriteAsync(
             "{\"status\":\"" + (healthy ? "healthy" : "degraded") +
+            "\",\"mode\":\"" + modeName +
             "\",\"lastBlockNumber\":" + currentBlockNumber +
             ",\"lastBlockAgeSeconds\":" + blockAge.ToString("F1", System.Globalization.CultureInfo.InvariantCulture) +
             ",\"makingProgress\":" + (makingProgress ? "true" : "false") +
+            syncLagField +
             ",\"chainId\":" + chainParams.ChainId + "}");
     });
 
@@ -369,124 +392,203 @@ try
         return Microsoft.AspNetCore.Http.Results.Ok(response);
     });
 
-    if (config.IsConsensusMode)
+    switch (config.ResolvedMode)
     {
-        // === CONSENSUS MODE ===
-        // Multi-node operation with P2P networking and BFT consensus
-        var slashingEngine = new SlashingEngine(
-            stakingState,
-            app.Services.GetRequiredService<ILoggerFactory>().CreateLogger<SlashingEngine>());
-
-        // ZK compliance verifier — reads VKs from SchemaRegistry contract storage (COMPL-17)
-        var schemaRegistryAddress = Basalt.Execution.GenesisContractDeployer.Addresses.SchemaRegistry;
-        var zkVerifier = new Basalt.Compliance.ZkComplianceVerifier(schemaId =>
+        case NodeMode.Validator:
         {
-            // StorageMap key: "scr_vk:{schemaIdHex}", hashed to Hash256 via BLAKE3
-            var storageKey = "scr_vk:" + schemaId.ToHexString();
-            var slot = Basalt.Crypto.Blake3Hasher.Hash(System.Text.Encoding.UTF8.GetBytes(storageKey));
-            var raw = stateDbRef.GetStorage(schemaRegistryAddress, slot);
-            if (raw == null || raw.Length < 2 || raw[0] != 0x07) // 0x07 = TagString
-                return null;
-            var hexVk = System.Text.Encoding.UTF8.GetString(raw.AsSpan(1));
-            if (string.IsNullOrEmpty(hexVk))
-                return null;
-            try { return Convert.FromHexString(hexVk); }
-            catch { return null; }
-        });
-        // H9: No MockKycProvider in consensus mode — only governance-approved
-        // providers can issue attestations on mainnet/testnet.
-        var complianceEngine = new Basalt.Compliance.ComplianceEngine(
-            new Basalt.Compliance.IdentityRegistry(),
-            new Basalt.Compliance.SanctionsList(),
-            zkVerifier);
+            // === VALIDATOR MODE ===
+            // Multi-node operation with P2P networking and BFT consensus
+            var slashingEngine = new SlashingEngine(
+                stakingState,
+                app.Services.GetRequiredService<ILoggerFactory>().CreateLogger<SlashingEngine>());
 
-        var coordinator = new NodeCoordinator(
-            config, chainParams, chainManager, mempool, stateDbRef, validator, wsHandler,
-            app.Services.GetRequiredService<ILoggerFactory>(),
-            blockStore, receiptStore,
-            stakingState, slashingEngine,
-            complianceEngine,
-            stakingPersistence);
-
-        // E4: Wire solver manager into REST API adapter after NodeCoordinator is initialized
-        if (coordinator.SolverManager != null)
-            solverInfoAdapter.SetSolverManager(coordinator.SolverManager);
-
-        Log.Information("Basalt Node listening on {Urls}", string.Join(", ", app.Urls.DefaultIfEmpty($"http://localhost:{config.HttpPort}")));
-        Log.Information("Chain: {Network} (ChainId={ChainId})", chainParams.NetworkName, chainParams.ChainId);
-        Log.Information("Validator: index={Index}, address={Address}, P2P port={P2PPort}",
-            config.ValidatorIndex, config.ValidatorAddress, config.P2PPort);
-        Log.Information("Peers: {Peers}", string.Join(", ", config.Peers));
-
-        app.Lifetime.ApplicationStarted.Register(() =>
-        {
-            _ = Task.Run(async () =>
+            // ZK compliance verifier — reads VKs from SchemaRegistry contract storage (COMPL-17)
+            var schemaRegistryAddress = Basalt.Execution.GenesisContractDeployer.Addresses.SchemaRegistry;
+            var zkVerifier = new Basalt.Compliance.ZkComplianceVerifier(schemaId =>
             {
-                try
+                // StorageMap key: "scr_vk:{schemaIdHex}", hashed to Hash256 via BLAKE3
+                var storageKey = "scr_vk:" + schemaId.ToHexString();
+                var slot = Basalt.Crypto.Blake3Hasher.Hash(System.Text.Encoding.UTF8.GetBytes(storageKey));
+                var raw = stateDbRef.GetStorage(schemaRegistryAddress, slot);
+                if (raw == null || raw.Length < 2 || raw[0] != 0x07) // 0x07 = TagString
+                    return null;
+                var hexVk = System.Text.Encoding.UTF8.GetString(raw.AsSpan(1));
+                if (string.IsNullOrEmpty(hexVk))
+                    return null;
+                try { return Convert.FromHexString(hexVk); }
+                catch { return null; }
+            });
+            // H9: No MockKycProvider in consensus mode — only governance-approved
+            // providers can issue attestations on mainnet/testnet.
+            var complianceEngine = new Basalt.Compliance.ComplianceEngine(
+                new Basalt.Compliance.IdentityRegistry(),
+                new Basalt.Compliance.SanctionsList(),
+                zkVerifier);
+
+            var coordinator = new NodeCoordinator(
+                config, chainParams, chainManager, mempool, stateDbRef, validator, wsHandler,
+                app.Services.GetRequiredService<ILoggerFactory>(),
+                blockStore, receiptStore,
+                stakingState, slashingEngine,
+                complianceEngine,
+                stakingPersistence);
+
+            // E4: Wire solver manager into REST API adapter after NodeCoordinator is initialized
+            if (coordinator.SolverManager != null)
+                solverInfoAdapter.SetSolverManager(coordinator.SolverManager);
+
+            Log.Information("Basalt Node listening on {Urls}", string.Join(", ", app.Urls.DefaultIfEmpty($"http://localhost:{config.HttpPort}")));
+            Log.Information("Chain: {Network} (ChainId={ChainId})", chainParams.NetworkName, chainParams.ChainId);
+            Log.Information("Validator: index={Index}, address={Address}, P2P port={P2PPort}",
+                config.ValidatorIndex, config.ValidatorAddress, config.P2PPort);
+            Log.Information("Peers: {Peers}", string.Join(", ", config.Peers));
+
+            app.Lifetime.ApplicationStarted.Register(() =>
+            {
+                _ = Task.Run(async () =>
                 {
-                    await coordinator.StartAsync(app.Lifetime.ApplicationStopping);
-                }
-                catch (Exception ex)
+                    try
+                    {
+                        await coordinator.StartAsync(app.Lifetime.ApplicationStopping);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Fatal(ex, "Consensus coordinator failed to start");
+                    }
+                });
+            });
+
+            app.Lifetime.ApplicationStopping.Register(() =>
+            {
+                // L20: Add random jitter to stagger validator restarts and avoid thundering herd
+                var jitterMs = Random.Shared.Next(0, 3000);
+                Thread.Sleep(jitterMs);
+
+                Log.Information("Shutting down consensus coordinator...");
+                // N-18: Timeout to prevent shutdown deadlock
+                if (!coordinator.StopAsync().Wait(TimeSpan.FromSeconds(10)))
                 {
-                    Log.Fatal(ex, "Consensus coordinator failed to start");
+                    Log.Warning("Node coordinator did not stop within 10 seconds; forcing exit");
                 }
             });
-        });
+            break;
+        }
 
-        app.Lifetime.ApplicationStopping.Register(() =>
+        case NodeMode.Rpc:
         {
-            // L20: Add random jitter to stagger validator restarts and avoid thundering herd
-            var jitterMs = Random.Shared.Next(0, 3000);
-            Thread.Sleep(jitterMs);
+            // === RPC MODE ===
+            // Syncs finalized blocks from a trusted source via HTTP. Serves the full API
+            // without participating in consensus or P2P networking.
 
-            Log.Information("Shutting down consensus coordinator...");
-            // N-18: Timeout to prevent shutdown deadlock
-            if (!coordinator.StopAsync().Wait(TimeSpan.FromSeconds(10)))
+            if (blockStore == null)
             {
-                Log.Warning("Node coordinator did not stop within 10 seconds; forcing exit");
+                Log.Fatal("RPC mode requires BASALT_DATA_DIR for block persistence");
+                return 1;
             }
-        });
-    }
-    else
-    {
-        // === STANDALONE MODE ===
-        // Single-node block production on a timer (existing behavior)
 
-        // LOW-06: Warn if DataDir is set but blocks are not persisted in standalone mode
-        if (config.DataDir != null)
-            Log.Warning("DataDir is set but standalone mode does not persist blocks. State will be lost on restart.");
+            var loggerFactory = app.Services.GetRequiredService<ILoggerFactory>();
 
-        var proposer = Address.FromHexString("0x0000000000000000000000000000000000000001");
-        var blockProduction = new BlockProductionLoop(
-            chainParams, chainManager, mempool, stateDbRef, proposer,
-            app.Services.GetRequiredService<ILogger<BlockProductionLoop>>());
+            // Create execution components for block replay
+            IContractRuntime rpcContractRuntime = config.UseSandbox
+                ? new Basalt.Execution.VM.Sandbox.SandboxedContractRuntime(new Basalt.Execution.VM.Sandbox.SandboxConfiguration())
+                : new ManagedContractRuntime();
+            var rpcTxExecutor = new TransactionExecutor(chainParams, rpcContractRuntime, stakingState);
+            var rpcBlockBuilder = new BlockBuilder(chainParams, rpcTxExecutor, loggerFactory.CreateLogger<BlockBuilder>());
 
-        // Wire metrics and WebSocket to block production
-        blockProduction.OnBlockProduced += block =>
-        {
-            MetricsEndpoint.RecordBlock(block.Transactions.Count, block.Header.Timestamp);
-            _ = wsHandler.BroadcastNewBlock(block);
-        };
+            var rpcBlockApplier = new BlockApplier(
+                chainParams, chainManager, mempool, rpcTxExecutor, rpcBlockBuilder,
+                blockStore, receiptStore,
+                epochManager: null, // No epoch transitions in RPC mode (no consensus)
+                stakingState: stakingState,
+                stakingPersistence: stakingPersistence,
+                wsHandler,
+                loggerFactory.CreateLogger<BlockApplier>());
 
-        blockProduction.Start();
+            var rpcSyncService = new BlockSyncService(
+                config.SyncSource!,
+                rpcBlockApplier,
+                chainManager,
+                stateDbRef,
+                chainParams,
+                loggerFactory.CreateLogger<BlockSyncService>());
 
-        Log.Information("Basalt Node listening on {Urls}", string.Join(", ", app.Urls.DefaultIfEmpty("http://localhost:5000")));
-        Log.Information("Chain: {Network} (ChainId={ChainId})", chainParams.NetworkName, chainParams.ChainId);
-        Log.Information("Block time: {BlockTime}ms", chainParams.BlockTimeMs);
+            syncStatus = rpcSyncService;
 
-        app.Lifetime.ApplicationStopping.Register(() =>
-        {
-            // L20: Add random jitter to stagger restarts
-            var jitterMs = Random.Shared.Next(0, 3000);
-            Thread.Sleep(jitterMs);
+            var txForwarder = new HttpTxForwarder(
+                config.SyncSource!,
+                loggerFactory.CreateLogger<HttpTxForwarder>());
+            txForwarderRef.Set(txForwarder);
 
-            Log.Information("Shutting down block production...");
-            // N-18: Timeout to prevent shutdown deadlock
-            if (!blockProduction.StopAsync().Wait(TimeSpan.FromSeconds(10)))
+            Log.Information("Basalt RPC Node listening on {Urls}", string.Join(", ", app.Urls.DefaultIfEmpty($"http://localhost:{config.HttpPort}")));
+            Log.Information("Chain: {Network} (ChainId={ChainId})", chainParams.NetworkName, chainParams.ChainId);
+            Log.Information("Sync source: {Source}", config.SyncSource);
+
+            app.Lifetime.ApplicationStarted.Register(() =>
             {
-                Log.Warning("Block production did not stop within 10 seconds; forcing exit");
-            }
-        });
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await rpcSyncService.RunAsync(app.Lifetime.ApplicationStopping);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Fatal(ex, "Block sync service failed");
+                    }
+                });
+            });
+
+            app.Lifetime.ApplicationStopping.Register(() =>
+            {
+                Log.Information("Shutting down RPC sync service...");
+                txForwarder.Dispose();
+                rpcSyncService.DisposeAsync().AsTask().Wait(TimeSpan.FromSeconds(5));
+            });
+            break;
+        }
+
+        default:
+        {
+            // === STANDALONE MODE ===
+            // Single-node block production on a timer (existing behavior)
+
+            // LOW-06: Warn if DataDir is set but blocks are not persisted in standalone mode
+            if (config.DataDir != null)
+                Log.Warning("DataDir is set but standalone mode does not persist blocks. State will be lost on restart.");
+
+            var proposer = Address.FromHexString("0x0000000000000000000000000000000000000001");
+            var blockProduction = new BlockProductionLoop(
+                chainParams, chainManager, mempool, stateDbRef, proposer,
+                app.Services.GetRequiredService<ILogger<BlockProductionLoop>>());
+
+            // Wire metrics and WebSocket to block production
+            blockProduction.OnBlockProduced += block =>
+            {
+                MetricsEndpoint.RecordBlock(block.Transactions.Count, block.Header.Timestamp);
+                _ = wsHandler.BroadcastNewBlock(block);
+            };
+
+            blockProduction.Start();
+
+            Log.Information("Basalt Node listening on {Urls}", string.Join(", ", app.Urls.DefaultIfEmpty("http://localhost:5000")));
+            Log.Information("Chain: {Network} (ChainId={ChainId})", chainParams.NetworkName, chainParams.ChainId);
+            Log.Information("Block time: {BlockTime}ms", chainParams.BlockTimeMs);
+
+            app.Lifetime.ApplicationStopping.Register(() =>
+            {
+                // L20: Add random jitter to stagger restarts
+                var jitterMs = Random.Shared.Next(0, 3000);
+                Thread.Sleep(jitterMs);
+
+                Log.Information("Shutting down block production...");
+                // N-18: Timeout to prevent shutdown deadlock
+                if (!blockProduction.StopAsync().Wait(TimeSpan.FromSeconds(10)))
+                {
+                    Log.Warning("Block production did not stop within 10 seconds; forcing exit");
+                }
+            });
+            break;
+        }
     }
 
     await app.RunAsync();

--- a/src/node/Basalt.Node/Program.cs
+++ b/src/node/Basalt.Node/Program.cs
@@ -318,8 +318,8 @@ try
     var faucetLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Basalt.Faucet");
     FaucetEndpoint.MapFaucetEndpoint(app, stateDbRef, mempool, chainParams, faucetPrivateKey, faucetLogger, chainManager, txForwarder: txForwarderRef);
 
-    // Map WebSocket endpoint
-    app.UseWebSockets();
+    // Map WebSocket endpoint (keep-alive prevents Cloudflare Tunnel idle disconnects)
+    app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
     var wsHandler = new WebSocketHandler(chainManager);
     app.MapWebSocketEndpoint(wsHandler);
 

--- a/src/node/Basalt.Node/Program.cs
+++ b/src/node/Basalt.Node/Program.cs
@@ -257,6 +257,8 @@ try
     // R3-NEW-1: Use GlobalLimiter instead of named policy. Named policies require
     // explicit .RequireRateLimiting("per-ip") on each endpoint group; a global limiter
     // applies to all requests automatically without per-endpoint opt-in.
+    // RPC nodes get much higher limits since they are the public-facing API layer.
+    var isRpcMode = config.ResolvedMode == NodeMode.Rpc;
     builder.Services.AddRateLimiter(options =>
     {
         options.RejectionStatusCode = 429;
@@ -265,19 +267,20 @@ try
                 partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
                 factory: _ => new FixedWindowRateLimiterOptions
                 {
-                    PermitLimit = 100,
+                    PermitLimit = isRpcMode ? 1000 : 100,
                     Window = TimeSpan.FromMinutes(1),
                 }));
     });
 
     // R3-NEW-2: Restrict CORS to known origins. AllowAnyOrigin enables localhost CSRF where
     // a malicious website uses a visitor's browser as a proxy to a locally-running node.
-    // Allow any origin only when BASALT_DEBUG=1 is set (development mode).
+    // Allow any origin when BASALT_DEBUG=1 is set (development mode) or in RPC mode
+    // (public-facing API serving Explorer, Caldera, and third-party consumers).
     builder.Services.AddCors(options =>
     {
         options.AddDefaultPolicy(policy =>
         {
-            if (Environment.GetEnvironmentVariable("BASALT_DEBUG") == "1")
+            if (Environment.GetEnvironmentVariable("BASALT_DEBUG") == "1" || isRpcMode)
             {
                 policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader();
             }

--- a/src/node/Basalt.Node/Program.cs
+++ b/src/node/Basalt.Node/Program.cs
@@ -252,6 +252,9 @@ try
     builder.Services.AddSingleton(chainManager);
     builder.Services.AddSingleton(mempool);
     builder.Services.AddSingleton(validator);
+    // TxForwarderRef: inner forwarder is set later in the RPC branch; DI resolves lazily
+    var txForwarderRef = new TxForwarderRef();
+    builder.Services.AddSingleton<ITxForwarder>(txForwarderRef);
     builder.Services.AddGrpc();
 
     // R3-NEW-1: Use GlobalLimiter instead of named policy. Named policies require
@@ -309,13 +312,11 @@ try
     var contractRuntime = new ManagedContractRuntime();
     var solverInfoAdapter = new Basalt.Node.Solver.SolverInfoAdapter();
     solverInfoAdapter.SetMempool(mempool);
-    // TxForwarderRef is set later in the RPC branch (mutable wrapper avoids re-registration)
-    var txForwarderRef = new TxForwarderRef();
     RestApiEndpoints.MapBasaltEndpoints(app, chainManager, mempool, validator, stateDbRef, contractRuntime, receiptStore, chainParams: chainParams, solverProvider: solverInfoAdapter, blockStore: blockStore, txForwarder: txForwarderRef);
 
-    // Map faucet endpoint
+    // Map faucet endpoint (txForwarderRef set later in RPC branch)
     var faucetLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Basalt.Faucet");
-    FaucetEndpoint.MapFaucetEndpoint(app, stateDbRef, mempool, chainParams, faucetPrivateKey, faucetLogger, chainManager);
+    FaucetEndpoint.MapFaucetEndpoint(app, stateDbRef, mempool, chainParams, faucetPrivateKey, faucetLogger, chainManager, txForwarder: txForwarderRef);
 
     // Map WebSocket endpoint
     app.UseWebSockets();

--- a/src/node/Basalt.Node/Program.cs
+++ b/src/node/Basalt.Node/Program.cs
@@ -435,7 +435,8 @@ try
                 blockStore, receiptStore,
                 stakingState, slashingEngine,
                 complianceEngine,
-                stakingPersistence);
+                stakingPersistence,
+                rocksDbStore);
 
             // E4: Wire solver manager into REST API adapter after NodeCoordinator is initialized
             if (coordinator.SolverManager != null)

--- a/src/node/Basalt.Node/README.md
+++ b/src/node/Basalt.Node/README.md
@@ -19,7 +19,12 @@ docker run -p 5000:5000 -p 30303:30303 basalt-node
 
 ## Runtime Modes
 
-The node operates in one of two modes, determined by the `BASALT_VALIDATOR_INDEX` environment variable (along with `BASALT_PEERS`). If both are set (index >= 0 and at least one peer), the node runs in **consensus mode**; otherwise it falls back to **standalone mode**.
+The node operates in one of three modes, controlled by the `BASALT_MODE` environment variable (default: `auto`):
+
+- **`auto`** (default): If `BASALT_VALIDATOR_INDEX >= 0` and `BASALT_PEERS` is set, the node runs in **validator mode**; otherwise it falls back to **standalone mode**.
+- **`validator`**: Forces validator/consensus mode.
+- **`rpc`**: Runs as a read-only RPC node that syncs blocks from a trusted source (`BASALT_SYNC_SOURCE`) and serves the full API without participating in consensus.
+- **`standalone`**: Forces standalone mode with timer-based block production.
 
 ### Standalone Mode
 
@@ -33,7 +38,20 @@ The node operates in one of two modes, determined by the `BASALT_VALIDATOR_INDEX
 8. Wires metrics and WebSocket notifications to the block production loop
 9. Handles graceful shutdown on SIGINT/SIGTERM
 
-### Consensus Mode
+### RPC Mode
+
+Set `BASALT_MODE=rpc` and `BASALT_SYNC_SOURCE=http://validator-0:5000`. The RPC node:
+
+1. Syncs finalized blocks from the sync source via HTTP polling (`BlockSyncService`)
+2. Applies blocks locally via `BlockApplier` (executes transactions, runs DEX settlement, updates state)
+3. Serves the full REST API, gRPC, faucet, WebSocket, and Prometheus metrics
+4. Forwards submitted transactions to the sync source validator via `HttpTxForwarder`
+5. Reports sync lag in the `/v1/health` endpoint (returns 503 if more than 50 blocks behind)
+6. Uses relaxed rate limits (1000 req/min/IP vs 100) and open CORS for public-facing traffic
+
+No P2P, no consensus, no block production. Same binary, same Dockerfile.
+
+### Validator Mode
 
 1. Initializes Serilog structured logging
 2. Initializes RocksDB persistent storage (when `BASALT_DATA_DIR` is set) with `BlockStore` and `ReceiptStore`, or in-memory state
@@ -101,6 +119,8 @@ Environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `BASALT_MODE` | `auto` | Node mode: `auto`, `validator`, `rpc`, or `standalone` |
+| `BASALT_SYNC_SOURCE` | -- | HTTP URL of sync source (required for `rpc` mode, e.g. `http://validator-0:5000`) |
 | `BASALT_CHAIN_ID` | `31337` | Chain identifier |
 | `BASALT_NETWORK` | `basalt-devnet` | Network name |
 | `BASALT_VALIDATOR_INDEX` | `-1` | Validator index (enables consensus mode when >= 0 and `BASALT_PEERS` is set) |

--- a/src/node/Basalt.Node/TxForwarder.cs
+++ b/src/node/Basalt.Node/TxForwarder.cs
@@ -1,0 +1,81 @@
+using System.Net.Http.Json;
+using Basalt.Api.Rest;
+using Basalt.Core;
+using Basalt.Execution;
+using Microsoft.Extensions.Logging;
+
+namespace Basalt.Node;
+
+/// <summary>
+/// No-op forwarding for validators and standalone nodes.
+/// Transactions are already in the local mempool and gossipped via P2P.
+/// </summary>
+public sealed class NoOpTxForwarder : ITxForwarder
+{
+    public Task ForwardAsync(Transaction tx, CancellationToken ct) => Task.CompletedTask;
+}
+
+/// <summary>
+/// Forwards transactions from an RPC node to its sync source validator via HTTP.
+/// Fire-and-forget: logs warnings on failure but never throws.
+/// </summary>
+public sealed class HttpTxForwarder : ITxForwarder, IDisposable
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger? _logger;
+
+    public HttpTxForwarder(string syncSourceUrl, ILogger? logger = null)
+    {
+        _logger = logger;
+        _httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(syncSourceUrl.TrimEnd('/')),
+            Timeout = TimeSpan.FromSeconds(5),
+        };
+    }
+
+    public async Task ForwardAsync(Transaction tx, CancellationToken ct)
+    {
+        try
+        {
+            var request = new TransactionRequest
+            {
+                Type = (byte)tx.Type,
+                Nonce = tx.Nonce,
+                Sender = tx.Sender.ToHexString(),
+                To = tx.To.ToHexString(),
+                Value = tx.Value.ToString(),
+                GasLimit = tx.GasLimit,
+                GasPrice = tx.GasPrice.ToString(),
+                MaxFeePerGas = tx.IsEip1559 ? tx.MaxFeePerGas.ToString() : null,
+                MaxPriorityFeePerGas = tx.IsEip1559 ? tx.MaxPriorityFeePerGas.ToString() : null,
+                Data = tx.Data.Length > 0 ? Convert.ToHexString(tx.Data) : null,
+                Priority = tx.Priority,
+                ChainId = tx.ChainId,
+                Signature = Convert.ToHexString(tx.Signature.ToArray()),
+                SenderPublicKey = tx.SenderPublicKey.ToArray().Length > 0
+                    ? Convert.ToHexString(tx.SenderPublicKey.ToArray())
+                    : "",
+            };
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+
+            await _httpClient.PostAsJsonAsync(
+                "/v1/transactions",
+                request,
+                BasaltApiJsonContext.Default.TransactionRequest,
+                cts.Token);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning("Failed to forward tx {Hash} to sync source: {Message}",
+                tx.Hash.ToHexString()[..16], ex.Message);
+        }
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+}

--- a/src/storage/Basalt.Storage/RocksDb/BlockStore.cs
+++ b/src/storage/Basalt.Storage/RocksDb/BlockStore.cs
@@ -186,6 +186,38 @@ public sealed class BlockStore
         return key;
     }
 
+    /// <summary>
+    /// Atomically delete all block data for blocks after the target block number.
+    /// Used during fork rollback to remove divergent chain data.
+    /// </summary>
+    public void RollbackToBlock(ulong targetBlockNumber, ulong currentBlockNumber)
+    {
+        using var batch = _store.CreateWriteBatch();
+
+        for (ulong i = targetBlockNumber + 1; i <= currentBlockNumber; i++)
+        {
+            var numberKey = NumberToKey(i);
+
+            // Look up the block hash from the index so we can delete block data and raw block
+            var hashKey = _store.Get(RocksDbStore.CF.BlockIndex, numberKey);
+            if (hashKey != null)
+            {
+                batch.Delete(RocksDbStore.CF.Blocks, hashKey);
+                batch.Delete(RocksDbStore.CF.Blocks, RawBlockKeyFromHashBytes(hashKey));
+            }
+
+            batch.Delete(RocksDbStore.CF.BlockIndex, numberKey);
+            batch.Delete(RocksDbStore.CF.Blocks, BitmapKey(i));
+        }
+
+        // Update the latest block number metadata
+        var data = new byte[8];
+        BinaryPrimitives.WriteUInt64BigEndian(data, targetBlockNumber);
+        batch.Put(RocksDbStore.CF.Metadata, "latest_block"u8.ToArray(), data);
+
+        batch.Commit();
+    }
+
     private static byte[] BitmapKey(ulong blockNumber)
     {
         var key = new byte[4 + 8];

--- a/tests/Basalt.Consensus.Tests/PipelinedConsensusTests.cs
+++ b/tests/Basalt.Consensus.Tests/PipelinedConsensusTests.cs
@@ -127,7 +127,7 @@ public class PipelinedConsensusTests
 
         Hash256? finalizedHash = null;
         foreach (var node in nodes)
-            node.OnBlockFinalized += (hash, _, _) => finalizedHash = hash;
+            node.OnBlockFinalized = (hash, _, _) => { finalizedHash = hash; return true; };
 
         var blockHash = Blake3Hasher.Hash([1, 2, 3]);
         var blockData = new byte[] { 1, 2, 3 };
@@ -197,10 +197,11 @@ public class PipelinedConsensusTests
         var finalized = new List<ulong>();
         var pipeline = new PipelinedConsensus(validatorSet, v0.Id, v0.PrivateKey,
             new BlsSigner(), NullLogger<PipelinedConsensus>.Instance);
-        pipeline.OnBlockFinalized += (_, data, _) =>
+        pipeline.OnBlockFinalized = (_, data, _) =>
         {
             // Extract block number from data (we encode it as a single byte)
             finalized.Add(data[0]);
+            return true;
         };
 
         // Start rounds 1 and 2

--- a/tests/Basalt.Execution.Tests/ChainManagerTests.cs
+++ b/tests/Basalt.Execution.Tests/ChainManagerTests.cs
@@ -279,4 +279,86 @@ public class ChainManagerTests
             block!.Number.Should().Be(i);
         }
     }
+
+    [Fact]
+    public void RollbackTo_RemovesBlocksAfterTarget()
+    {
+        var chainManager = new ChainManager();
+        var genesis = CreateBlock(0, Hash256.Zero);
+        chainManager.AddBlock(genesis);
+
+        var blocks = new List<Block> { genesis };
+        var prevHash = genesis.Hash;
+        for (ulong i = 1; i <= 5; i++)
+        {
+            var block = CreateBlock(i, prevHash);
+            chainManager.AddBlock(block);
+            blocks.Add(block);
+            prevHash = block.Hash;
+        }
+
+        chainManager.LatestBlockNumber.Should().Be(5);
+
+        // Roll back to block 3
+        chainManager.RollbackTo(blocks[3]);
+
+        chainManager.LatestBlockNumber.Should().Be(3);
+        chainManager.LatestBlock!.Hash.Should().Be(blocks[3].Hash);
+
+        // Blocks 0-3 should still exist
+        for (int i = 0; i <= 3; i++)
+            chainManager.GetBlockByNumber((ulong)i).Should().NotBeNull();
+
+        // Blocks 4-5 should be removed
+        chainManager.GetBlockByNumber(4).Should().BeNull();
+        chainManager.GetBlockByNumber(5).Should().BeNull();
+        chainManager.GetBlockByHash(blocks[4].Hash).Should().BeNull();
+        chainManager.GetBlockByHash(blocks[5].Hash).Should().BeNull();
+    }
+
+    [Fact]
+    public void RollbackTo_CanAddNewBlocksAfterRollback()
+    {
+        var chainManager = new ChainManager();
+        var genesis = CreateBlock(0, Hash256.Zero);
+        chainManager.AddBlock(genesis);
+
+        var block1 = CreateBlock(1, genesis.Hash);
+        chainManager.AddBlock(block1);
+
+        var block2 = CreateBlock(2, block1.Hash);
+        chainManager.AddBlock(block2);
+
+        // Roll back to block 1
+        chainManager.RollbackTo(block1);
+        chainManager.LatestBlockNumber.Should().Be(1);
+
+        // Can add a new block 2 (different from original)
+        var newBlock2 = CreateBlock(2, block1.Hash);
+        var result = chainManager.AddBlock(newBlock2);
+        result.IsSuccess.Should().BeTrue();
+        chainManager.LatestBlockNumber.Should().Be(2);
+    }
+
+    [Fact]
+    public void RollbackTo_Genesis_RemovesAllBlocksExceptGenesis()
+    {
+        var chainManager = new ChainManager();
+        var genesis = CreateBlock(0, Hash256.Zero);
+        chainManager.AddBlock(genesis);
+
+        var prevHash = genesis.Hash;
+        for (ulong i = 1; i <= 3; i++)
+        {
+            var block = CreateBlock(i, prevHash);
+            chainManager.AddBlock(block);
+            prevHash = block.Hash;
+        }
+
+        chainManager.RollbackTo(genesis);
+
+        chainManager.LatestBlockNumber.Should().Be(0);
+        chainManager.LatestBlock!.Hash.Should().Be(genesis.Hash);
+        chainManager.GetBlockByNumber(1).Should().BeNull();
+    }
 }

--- a/tests/Basalt.Network.Tests/MessageCodecTests.cs
+++ b/tests/Basalt.Network.Tests/MessageCodecTests.cs
@@ -796,4 +796,64 @@ public class MessageCodecTests
         var result = Assert.IsType<SolverSolutionMessage>(deserialized);
         Assert.Empty(result.SerializedFills);
     }
+
+    [Fact]
+    public void Roundtrip_ForkHashRequestMessage()
+    {
+        var original = new ForkHashRequestMessage
+        {
+            SenderId = MakePeerId(33),
+            Timestamp = Now(),
+            BlockNumber = 12345UL,
+        };
+
+        var bytes = MessageCodec.Serialize(original);
+        var deserialized = MessageCodec.Deserialize(bytes);
+
+        var result = Assert.IsType<ForkHashRequestMessage>(deserialized);
+        AssertHeaderEquals(original, result);
+        Assert.Equal(original.BlockNumber, result.BlockNumber);
+    }
+
+    [Fact]
+    public void Roundtrip_ForkHashResponseMessage()
+    {
+        var original = new ForkHashResponseMessage
+        {
+            SenderId = MakePeerId(34),
+            Timestamp = Now(),
+            BlockNumber = 12345UL,
+            BlockHash = MakeHash(0xAB),
+            HasBlock = true,
+        };
+
+        var bytes = MessageCodec.Serialize(original);
+        var deserialized = MessageCodec.Deserialize(bytes);
+
+        var result = Assert.IsType<ForkHashResponseMessage>(deserialized);
+        AssertHeaderEquals(original, result);
+        Assert.Equal(original.BlockNumber, result.BlockNumber);
+        Assert.Equal(original.BlockHash, result.BlockHash);
+        Assert.True(result.HasBlock);
+    }
+
+    [Fact]
+    public void Roundtrip_ForkHashResponseMessage_NoBlock()
+    {
+        var original = new ForkHashResponseMessage
+        {
+            SenderId = MakePeerId(35),
+            Timestamp = Now(),
+            BlockNumber = 99999UL,
+            BlockHash = Hash256.Zero,
+            HasBlock = false,
+        };
+
+        var bytes = MessageCodec.Serialize(original);
+        var deserialized = MessageCodec.Deserialize(bytes);
+
+        var result = Assert.IsType<ForkHashResponseMessage>(deserialized);
+        Assert.Equal(original.BlockNumber, result.BlockNumber);
+        Assert.False(result.HasBlock);
+    }
 }

--- a/tests/Basalt.Node.Tests/NodeConfigurationTests.cs
+++ b/tests/Basalt.Node.Tests/NodeConfigurationTests.cs
@@ -113,4 +113,81 @@ public class NodeConfigurationTests
         result.Should().StartWith("/");
         result.Should().EndWith("data/basalt");
     }
+
+    // ── ResolvedMode tests ──
+
+    [Fact]
+    public void ResolvedMode_Default_ReturnsStandalone()
+    {
+        var config = new NodeConfiguration();
+        config.ResolvedMode.Should().Be(NodeMode.Standalone);
+    }
+
+    [Fact]
+    public void ResolvedMode_ExplicitStandalone_ReturnsStandalone()
+    {
+        var config = new NodeConfiguration { Mode = "standalone" };
+        config.ResolvedMode.Should().Be(NodeMode.Standalone);
+    }
+
+    [Fact]
+    public void ResolvedMode_ExplicitValidator_ReturnsValidator()
+    {
+        var config = new NodeConfiguration { Mode = "validator" };
+        config.ResolvedMode.Should().Be(NodeMode.Validator);
+    }
+
+    [Fact]
+    public void ResolvedMode_AutoWithPeersAndIndex_ReturnsValidator()
+    {
+        var config = new NodeConfiguration
+        {
+            Mode = "auto",
+            ValidatorIndex = 0,
+            Peers = ["peer1:30303"],
+        };
+        config.ResolvedMode.Should().Be(NodeMode.Validator);
+    }
+
+    [Fact]
+    public void ResolvedMode_Rpc_WithSyncSource_ReturnsRpc()
+    {
+        var config = new NodeConfiguration
+        {
+            Mode = "rpc",
+            SyncSource = "http://validator-0:5000",
+        };
+        config.ResolvedMode.Should().Be(NodeMode.Rpc);
+    }
+
+    [Fact]
+    public void ResolvedMode_Rpc_WithoutSyncSource_Throws()
+    {
+        var config = new NodeConfiguration { Mode = "rpc" };
+        var act = () => config.ResolvedMode;
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*BASALT_SYNC_SOURCE*");
+    }
+
+    [Fact]
+    public void ResolvedMode_CaseInsensitive()
+    {
+        var config = new NodeConfiguration
+        {
+            Mode = "RPC",
+            SyncSource = "http://validator-0:5000",
+        };
+        config.ResolvedMode.Should().Be(NodeMode.Rpc);
+    }
+
+    [Fact]
+    public void IsConsensusMode_RpcMode_ReturnsFalse()
+    {
+        var config = new NodeConfiguration
+        {
+            Mode = "rpc",
+            SyncSource = "http://validator-0:5000",
+        };
+        config.IsConsensusMode.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## Summary

- Add a third node mode (**RPC**) alongside Validator and Standalone — syncs finalized blocks from a trusted source via HTTP and serves the full API without participating in consensus
- Extract shared `BlockApplier` from NodeCoordinator to eliminate duplicated block-application logic across 3 code paths
- Add `BlockSyncService` (HTTP polling with exponential backoff), `HttpTxForwarder` (fire-and-forget tx forwarding to validators), and sync endpoints (`/v1/sync/status`, `/v1/sync/blocks`)
- Forward faucet and gRPC transactions to validators when running in RPC mode
- Relax rate limits (1000 req/min/IP) and CORS for public-facing RPC nodes
- Enable 30s WebSocket keep-alive to prevent proxy idle disconnects
- Fix price-history endpoint returning millisecond timestamps instead of seconds
- Add `rpc-0` service to both devnet and testnet Docker Compose, route public traffic through RPC via Caddy
- 8 new NodeConfiguration tests for `ResolvedMode` tri-state detection

## New environment variables

| Variable | Default | Description |
|----------|---------|-------------|
| `BASALT_MODE` | `auto` | Node mode: `auto`, `validator`, `rpc`, or `standalone` |
| `BASALT_SYNC_SOURCE` | — | HTTP URL of sync source (required for `rpc` mode) |

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 2,789 tests pass, 0 failures
- [x] `ResolvedMode` tests cover all mode combinations (auto, rpc, validator, standalone, missing SyncSource)
- [x] Docker: `docker compose up` — 4 validators + 1 RPC, verify RPC syncs and serves API
- [x] Testnet: verify faucet transactions reach validators via tx forwarding
- [x] Testnet: verify WebSocket stays connected through Caddy reverse proxy