### PR TITLE
perf: fix consensus stability, CPU saturation, and memory growth on idle chains

### DIFF
--- a/src/api/Basalt.Api.Rest/WebSocketEndpoint.cs
+++ b/src/api/Basalt.Api.Rest/WebSocketEndpoint.cs
@@ -36,6 +36,12 @@ public sealed class WebSocketHandler : IDisposable
     /// </summary>
     public async Task BroadcastNewBlock(Block block)
     {
+        // Fast path: skip all allocations when no clients are connected.
+        // On an idle chain producing blocks every 3s, this avoids creating
+        // WebSocketBlockMessage + JSON string + byte[] per block for nothing.
+        if (_connections.IsEmpty)
+            return;
+
         var message = new WebSocketBlockMessage
         {
             Type = "new_block",

--- a/src/consensus/Basalt.Consensus/BasaltBft.cs
+++ b/src/consensus/Basalt.Consensus/BasaltBft.cs
@@ -43,6 +43,12 @@ public sealed class BasaltBft
     private readonly TimeSpan _viewTimeout;
     private ulong? _viewChangeRequestedForView;
 
+    // Commit bitmap tracking: when a late-arriving COMMIT vote arrives after quorum was
+    // already reached, we re-broadcast an updated aggregate with the fuller bitmap so that
+    // all validators' participation is recorded for inactivity slashing.
+    private ulong _lastCommitBitmap;
+    private Hash256 _lastCommitBlockHash;
+
     // Callbacks
     // Events raised during consensus - consumed by the node integration layer
 #pragma warning disable CS0067
@@ -556,10 +562,29 @@ public sealed class BasaltBft
                 // Build and broadcast aggregate COMMIT QC
                 var aggregate = BuildAggregateVote(view, blockHash, VotePhase.Commit);
                 if (aggregate != null)
+                {
+                    _lastCommitBitmap = aggregate.VoterBitmap;
+                    _lastCommitBlockHash = blockHash;
                     OnAggregateVote?.Invoke(aggregate);
+                }
 
                 OnBlockFinalized?.Invoke(blockHash, _currentProposalData ?? [], aggregate?.VoterBitmap ?? 0UL);
                 return null;
+            }
+
+            // Late-arriving COMMIT vote after quorum was already reached.
+            // Rebuild the aggregate with the additional signature so that the updated
+            // bitmap (with better validator participation) is broadcast to all peers.
+            // This prevents systematic inactivity slashing of validators whose votes
+            // arrive slightly after the quorum-triggering vote due to thread scheduling.
+            if (_state == ConsensusState.Finalized && votes.Count > _validatorSet.QuorumThreshold)
+            {
+                var updatedAggregate = BuildAggregateVote(view, blockHash, VotePhase.Commit);
+                if (updatedAggregate != null && updatedAggregate.VoterBitmap != _lastCommitBitmap)
+                {
+                    _lastCommitBitmap = updatedAggregate.VoterBitmap;
+                    OnAggregateVote?.Invoke(updatedAggregate);
+                }
             }
         }
 
@@ -721,13 +746,30 @@ public sealed class BasaltBft
 
     private ConsensusVoteMessage? HandleCommitQC(AggregateVoteMessage aggregate)
     {
-        if (_state != ConsensusState.Committing)
+        if (_state == ConsensusState.Committing)
+        {
+            _state = ConsensusState.Finalized;
+            _lastCommitBitmap = aggregate.VoterBitmap;
+            _lastCommitBlockHash = aggregate.BlockHash;
+            _logger.LogInformation("COMMIT QC received — block {Hash} finalized at height {Height}",
+                aggregate.BlockHash, _currentBlockNumber);
+            OnBlockFinalized?.Invoke(aggregate.BlockHash, _currentProposalData ?? [], aggregate.VoterBitmap);
             return null;
+        }
 
-        _state = ConsensusState.Finalized;
-        _logger.LogInformation("COMMIT QC received — block {Hash} finalized at height {Height}",
-            aggregate.BlockHash, _currentBlockNumber);
-        OnBlockFinalized?.Invoke(aggregate.BlockHash, _currentProposalData ?? [], aggregate.VoterBitmap);
+        // Accept updated COMMIT aggregate with a fuller bitmap (more validator participation)
+        // after we've already finalized. This happens when the leader re-broadcasts an updated
+        // aggregate after collecting late-arriving votes.
+        if (_state == ConsensusState.Finalized
+            && aggregate.BlockHash == _lastCommitBlockHash
+            && aggregate.VoterBitmap != _lastCommitBitmap
+            && System.Numerics.BitOperations.PopCount(aggregate.VoterBitmap) > System.Numerics.BitOperations.PopCount(_lastCommitBitmap))
+        {
+            _lastCommitBitmap = aggregate.VoterBitmap;
+            // Re-fire with updated bitmap so the node records the fuller participation
+            OnBlockFinalized?.Invoke(aggregate.BlockHash, [], aggregate.VoterBitmap);
+        }
+
         return null;
     }
 

--- a/src/consensus/Basalt.Consensus/BasaltBft.cs
+++ b/src/consensus/Basalt.Consensus/BasaltBft.cs
@@ -25,6 +25,7 @@ public sealed class BasaltBft
     private readonly IBlsSigner _blsSigner;
     private readonly ILogger<BasaltBft> _logger;
     private readonly uint _chainId;
+    private readonly byte[] _cachedPublicKey;
 
     // State
     private ulong _currentView;
@@ -74,6 +75,7 @@ public sealed class BasaltBft
         _logger = logger;
         _viewTimeout = viewTimeout ?? TimeSpan.FromSeconds(5);
         _chainId = chainId;
+        _cachedPublicKey = _blsSigner.GetPublicKey(privateKey);
     }
 
     /// <summary>
@@ -460,7 +462,7 @@ public sealed class BasaltBft
             Span<byte> viewPayload = stackalloc byte[ViewChangePayloadSize];
             WriteViewChangeSigningPayload(viewPayload, _chainId, viewChange.ProposedView);
             var signature = new BlsSignature(_blsSigner.Sign(_privateKey, viewPayload));
-            var publicKey = new BlsPublicKey(_blsSigner.GetPublicKey(_privateKey));
+            var publicKey = new BlsPublicKey(_cachedPublicKey);
 
             return new ViewChangeMessage
             {
@@ -570,7 +572,7 @@ public sealed class BasaltBft
         WriteConsensusSigningPayload(sigPayload, _chainId, phase, _currentView, _currentBlockNumber, blockHash);
         var signatureBytes = _blsSigner.Sign(_privateKey, sigPayload);
         var signature = new BlsSignature(signatureBytes);
-        var publicKey = new BlsPublicKey(_blsSigner.GetPublicKey(_privateKey));
+        var publicKey = new BlsPublicKey(_cachedPublicKey);
 
         // Track signature for aggregation (dedup by public key, O(1))
         var sigKey = (_currentView, phase);
@@ -765,7 +767,7 @@ public sealed class BasaltBft
         Span<byte> viewPayload = stackalloc byte[ViewChangePayloadSize];
         WriteViewChangeSigningPayload(viewPayload, _chainId, proposedView);
         var signature = new BlsSignature(_blsSigner.Sign(_privateKey, viewPayload));
-        var publicKey = new BlsPublicKey(_blsSigner.GetPublicKey(_privateKey));
+        var publicKey = new BlsPublicKey(_cachedPublicKey);
 
         return new ViewChangeMessage
         {

--- a/src/consensus/Basalt.Consensus/BasaltBft.cs
+++ b/src/consensus/Basalt.Consensus/BasaltBft.cs
@@ -322,7 +322,11 @@ public sealed class BasaltBft
         // validator's SenderId, causing aggregate QC verification to fail and stalling finalization.
         var voteVInfo = _validatorSet.GetByPeerId(vote.SenderId);
         if (voteVInfo == null || !voteVInfo.BlsPublicKeyBytes.AsSpan().SequenceEqual(vote.VoterPublicKey.ToArray()))
+        {
+            _logger.LogWarning("Vote from {Sender} dropped: BLS key mismatch (identity not yet resolved via handshake?)",
+                vote.SenderId);
             return null;
+        }
 
         // F-CON-02: Verify vote is for the correct block hash
         if (vote.BlockHash != _currentProposalHash)

--- a/src/consensus/Basalt.Consensus/PipelinedConsensus.cs
+++ b/src/consensus/Basalt.Consensus/PipelinedConsensus.cs
@@ -25,6 +25,7 @@ public sealed class PipelinedConsensus
     private readonly IBlsSigner _blsSigner;
     private readonly ILogger<PipelinedConsensus> _logger;
     private readonly uint _chainId;
+    private readonly byte[] _cachedPublicKey;
 
     // Active consensus rounds (one per block height)
     private readonly ConcurrentDictionary<ulong, ConsensusRound> _activeRounds = new();
@@ -76,6 +77,7 @@ public sealed class PipelinedConsensus
         _logger = logger;
         _lastFinalizedBlock = lastFinalizedBlock;
         _roundTimeout = roundTimeout ?? TimeSpan.FromSeconds(2);
+        _cachedPublicKey = blsSigner.GetPublicKey(privateKey);
     }
 
     /// <summary>
@@ -182,7 +184,7 @@ public sealed class PipelinedConsensus
 
         // Self-vote PREPARE with signature tracking
         RecordVote(round, VotePhase.Prepare, _localPeerId, signatureBytes,
-            _blsSigner.GetPublicKey(_privateKey));
+            _cachedPublicKey);
 
         // Cascade through phases if self-vote alone meets quorum (e.g., single validator)
         TryCascadeFromPrepare(round);
@@ -327,6 +329,9 @@ public sealed class PipelinedConsensus
     /// </summary>
     public ViewChangeMessage? CheckViewTimeout()
     {
+        if (_activeRounds.IsEmpty)
+            return null;
+
         foreach (var (blockNumber, round) in _activeRounds)
         {
             if (round.State == ConsensusState.Finalized || round.State == ConsensusState.Idle)
@@ -438,7 +443,7 @@ public sealed class PipelinedConsensus
             Span<byte> viewPayload = stackalloc byte[ViewChangePayloadSize];
             WriteViewChangeSigningPayload(viewPayload, _chainId, viewChange.ProposedView);
             var signature = new BlsSignature(_blsSigner.Sign(_privateKey, viewPayload));
-            var publicKey = new BlsPublicKey(_blsSigner.GetPublicKey(_privateKey));
+            var publicKey = new BlsPublicKey(_cachedPublicKey);
 
             return new ViewChangeMessage
             {
@@ -462,7 +467,15 @@ public sealed class PipelinedConsensus
         foreach (var (blockNumber, round) in _activeRounds)
         {
             if (round.State == ConsensusState.Finalized)
+            {
+                // Release large allocations before removing the round —
+                // prevents BlockData + signature lists from lingering until GC.
+                round.BlockData = null;
+                round.PrepareSignatures.Clear();
+                round.PreCommitSignatures.Clear();
+                round.CommitSignatures.Clear();
                 _activeRounds.TryRemove(blockNumber, out _);
+            }
         }
     }
 
@@ -669,7 +682,7 @@ public sealed class PipelinedConsensus
         Span<byte> sigPayload = stackalloc byte[ConsensusPayloadSize];
         WriteConsensusSigningPayload(sigPayload, _chainId, phase, round.View, round.BlockNumber, round.BlockHash);
         var signatureBytes = _blsSigner.Sign(_privateKey, sigPayload);
-        var publicKeyBytes = _blsSigner.GetPublicKey(_privateKey);
+        var publicKeyBytes = _cachedPublicKey;
         RecordVote(round, phase, _localPeerId, signatureBytes, publicKeyBytes);
     }
 
@@ -679,7 +692,7 @@ public sealed class PipelinedConsensus
         WriteConsensusSigningPayload(sigPayload, _chainId, phase, round.View, round.BlockNumber, round.BlockHash);
         var signatureBytes = _blsSigner.Sign(_privateKey, sigPayload);
         var signature = new BlsSignature(signatureBytes);
-        var publicKeyBytes = _blsSigner.GetPublicKey(_privateKey);
+        var publicKeyBytes = _cachedPublicKey;
         var publicKey = new BlsPublicKey(publicKeyBytes);
 
         var vote = new ConsensusVoteMessage
@@ -706,7 +719,7 @@ public sealed class PipelinedConsensus
         Span<byte> viewPayload = stackalloc byte[ViewChangePayloadSize];
         WriteViewChangeSigningPayload(viewPayload, _chainId, proposedView);
         var signature = new BlsSignature(_blsSigner.Sign(_privateKey, viewPayload));
-        var publicKey = new BlsPublicKey(_blsSigner.GetPublicKey(_privateKey));
+        var publicKey = new BlsPublicKey(_cachedPublicKey);
 
         return new ViewChangeMessage
         {

--- a/src/consensus/Basalt.Consensus/Staking/SlashingEngine.cs
+++ b/src/consensus/Basalt.Consensus/Staking/SlashingEngine.cs
@@ -19,6 +19,11 @@ public sealed class SlashingEngine
     private readonly object _historyLock = new();
 
     /// <summary>
+    /// Maximum slashing events retained in memory. Oldest events are evicted when exceeded.
+    /// </summary>
+    private const int MaxHistoryEntries = 10_000;
+
+    /// <summary>
     /// Double-sign penalty: 100% of stake.
     /// </summary>
     public const int DoubleSignPenaltyPercent = 100;
@@ -108,7 +113,13 @@ public sealed class SlashingEngine
         };
 
         lock (_historyLock)
+        {
             _slashingHistory.Add(evt);
+
+            // Evict oldest entries to prevent unbounded memory growth
+            if (_slashingHistory.Count > MaxHistoryEntries)
+                _slashingHistory.RemoveRange(0, _slashingHistory.Count - MaxHistoryEntries);
+        }
 
         var remainingStake = _stakingState.GetStakeInfo(validator)?.TotalStake ?? UInt256.Zero;
         _logger.LogWarning(

--- a/src/consensus/Basalt.Consensus/Staking/StakingState.cs
+++ b/src/consensus/Basalt.Consensus/Staking/StakingState.cs
@@ -52,6 +52,7 @@ public sealed class StakingState : IStakingState
 
     /// <summary>
     /// Add stake to an existing validator.
+    /// Re-activates the validator if TotalStake reaches MinValidatorStake after the addition.
     /// </summary>
     public StakingResult AddStake(Address validatorAddress, UInt256 amount)
     {
@@ -62,6 +63,11 @@ public sealed class StakingState : IStakingState
 
             info.SelfStake += amount;
             info.TotalStake += amount;
+
+            // Re-activate if stake recovered above minimum (e.g. after inactivity slashing)
+            if (!info.IsActive && info.TotalStake >= MinValidatorStake)
+                info.IsActive = true;
+
             return StakingResult.Ok();
         }
     }

--- a/src/execution/Basalt.Execution/BlockBuilder.cs
+++ b/src/execution/Basalt.Execution/BlockBuilder.cs
@@ -249,7 +249,11 @@ public sealed class BlockBuilder
         }
 
         // ═══ TWAP carry-forward: update accumulators for all pools using current price ═══
-        RunTwapCarryForward(stateDb, blockNumber);
+        // Skip entirely when no DEX pools exist — avoids DexState construction + storage reads on idle blocks.
+        var dexStateCheck = new DexState(stateDb);
+        var poolCount = dexStateCheck.GetPoolCount();
+        if (poolCount > 0)
+            RunTwapCarryForward(stateDb, blockNumber);
 
         // ═══ Phase B: Batch auction — group intents by pair, compute clearing prices ═══
         var batchResults = new List<BatchResult>();
@@ -411,8 +415,11 @@ public sealed class BlockBuilder
         SkipBatchAuction:
 
         // ═══ Phase B2: Standalone limit order matching for pools not covered by swap intents ═══
-        var standaloneResults = RunStandaloneLimitOrderMatching(stateDb, blockNumber, settledPoolIds);
-        batchResults.AddRange(standaloneResults);
+        if (poolCount > 0)
+        {
+            var standaloneResults = RunStandaloneLimitOrderMatching(stateDb, blockNumber, settledPoolIds);
+            batchResults.AddRange(standaloneResults);
+        }
 
         // ═══ Phase C: Settlement — apply fills, update reserves, generate receipts ═══
         bool gasLimitReached = false;

--- a/src/execution/Basalt.Execution/BlockBuilder.cs
+++ b/src/execution/Basalt.Execution/BlockBuilder.cs
@@ -568,23 +568,27 @@ public sealed class BlockBuilder
     /// on the given state database. Called during block finalization and sync to ensure canonical
     /// state reflects DEX activity.
     /// </summary>
+    private static readonly List<TransactionReceipt> s_emptyReceipts = [];
+
     public List<TransactionReceipt> ApplyDexSettlement(IStateDatabase stateDb, BlockHeader blockHeader)
     {
-        var allReceipts = new List<TransactionReceipt>();
+        // Fast path: skip all DEX operations when no pools exist.
+        // On an idle chain this avoids allocating DexState objects, reading pool state,
+        // and running TWAP/order logic on every block.
+        var poolCheck = new DexState(stateDb);
+        if (poolCheck.GetPoolCount() == 0)
+            return s_emptyReceipts;
 
         RunTwapCarryForward(stateDb, blockHeader.Number);
 
         // Prune old TWAP snapshots to prevent unbounded storage cache growth.
-        // Each pool creates one unique storage key per block; without pruning,
-        // the flat state cache grows by (pool_count) entries every block, causing
-        // Fork() to become progressively more expensive and eventually saturate CPU.
-        var dexStateForPrune = new DexState(stateDb);
-        dexStateForPrune.PruneTwapSnapshots(blockHeader.Number);
+        poolCheck.PruneTwapSnapshots(blockHeader.Number);
 
         var batchResults = RunStandaloneLimitOrderMatching(stateDb, blockHeader.Number, new HashSet<ulong>());
         if (batchResults.Count == 0)
-            return allReceipts;
+            return s_emptyReceipts;
 
+        var allReceipts = new List<TransactionReceipt>();
         var emptyIntentMap = new Dictionary<Hash256, Transaction>();
         foreach (var result in batchResults)
         {

--- a/src/execution/Basalt.Execution/BlockBuilder.cs
+++ b/src/execution/Basalt.Execution/BlockBuilder.cs
@@ -568,8 +568,6 @@ public sealed class BlockBuilder
     /// on the given state database. Called during block finalization and sync to ensure canonical
     /// state reflects DEX activity.
     /// </summary>
-    private static readonly List<TransactionReceipt> s_emptyReceipts = [];
-
     public List<TransactionReceipt> ApplyDexSettlement(IStateDatabase stateDb, BlockHeader blockHeader)
     {
         // Fast path: skip all DEX operations when no pools exist.
@@ -577,7 +575,7 @@ public sealed class BlockBuilder
         // and running TWAP/order logic on every block.
         var poolCheck = new DexState(stateDb);
         if (poolCheck.GetPoolCount() == 0)
-            return s_emptyReceipts;
+            return [];
 
         RunTwapCarryForward(stateDb, blockHeader.Number);
 
@@ -586,7 +584,7 @@ public sealed class BlockBuilder
 
         var batchResults = RunStandaloneLimitOrderMatching(stateDb, blockHeader.Number, new HashSet<ulong>());
         if (batchResults.Count == 0)
-            return s_emptyReceipts;
+            return [];
 
         var allReceipts = new List<TransactionReceipt>();
         var emptyIntentMap = new Dictionary<Hash256, Transaction>();

--- a/src/execution/Basalt.Execution/Mempool.cs
+++ b/src/execution/Basalt.Execution/Mempool.cs
@@ -174,15 +174,13 @@ public sealed class Mempool
     /// EXEC-10: Prevents nonce gap issues where a higher-nonce tx would fail execution
     /// because a required lower-nonce tx is missing from the batch.
     /// </summary>
-    private static readonly List<Transaction> s_emptyTxList = [];
-
     public List<Transaction> GetPending(int maxCount, IStateDatabase? stateDb = null)
     {
         lock (_lock)
         {
             // Fast path: empty mempool — avoid all allocations
             if (_orderedEntries.Count == 0)
-                return s_emptyTxList;
+                return [];
 
             if (stateDb == null)
             {
@@ -309,7 +307,7 @@ public sealed class Mempool
         lock (_lock)
         {
             if (_dexIntentEntries.Count == 0)
-                return s_emptyTxList;
+                return [];
 
             var result = new List<Transaction>();
             foreach (var entry in _dexIntentEntries)
@@ -385,15 +383,14 @@ public sealed class Mempool
     /// </summary>
     public int PruneStale(IStateDatabase stateDb, UInt256 baseFee)
     {
-        // Fast path: skip when mempool is empty (common on idle chains).
-        // Avoids lock acquisition, list allocation, and trie reads.
-        if (_transactions.Count == 0 && _dexIntentTransactions.Count == 0)
-            return 0;
-
         var toRemove = new List<Hash256>();
         var toRemoveIntents = new List<Hash256>();
         lock (_lock)
         {
+            // Fast path: skip when mempool is empty (common on idle chains).
+            if (_transactions.Count == 0 && _dexIntentTransactions.Count == 0)
+                return 0;
+
             foreach (var tx in _transactions.Values)
             {
                 var account = stateDb.GetAccount(tx.Sender);

--- a/src/execution/Basalt.Execution/Mempool.cs
+++ b/src/execution/Basalt.Execution/Mempool.cs
@@ -385,6 +385,11 @@ public sealed class Mempool
     /// </summary>
     public int PruneStale(IStateDatabase stateDb, UInt256 baseFee)
     {
+        // Fast path: skip when mempool is empty (common on idle chains).
+        // Avoids lock acquisition, list allocation, and trie reads.
+        if (_transactions.Count == 0 && _dexIntentTransactions.Count == 0)
+            return 0;
+
         var toRemove = new List<Hash256>();
         var toRemoveIntents = new List<Hash256>();
         lock (_lock)

--- a/src/execution/Basalt.Execution/Mempool.cs
+++ b/src/execution/Basalt.Execution/Mempool.cs
@@ -174,10 +174,16 @@ public sealed class Mempool
     /// EXEC-10: Prevents nonce gap issues where a higher-nonce tx would fail execution
     /// because a required lower-nonce tx is missing from the batch.
     /// </summary>
+    private static readonly List<Transaction> s_emptyTxList = [];
+
     public List<Transaction> GetPending(int maxCount, IStateDatabase? stateDb = null)
     {
         lock (_lock)
         {
+            // Fast path: empty mempool — avoid all allocations
+            if (_orderedEntries.Count == 0)
+                return s_emptyTxList;
+
             if (stateDb == null)
             {
                 var fast = new List<Transaction>(Math.Min(maxCount, _orderedEntries.Count));
@@ -302,6 +308,9 @@ public sealed class Mempool
     {
         lock (_lock)
         {
+            if (_dexIntentEntries.Count == 0)
+                return s_emptyTxList;
+
             var result = new List<Transaction>();
             foreach (var entry in _dexIntentEntries)
             {

--- a/src/execution/Basalt.Execution/VM/Sandbox/ResourceLimiter.cs
+++ b/src/execution/Basalt.Execution/VM/Sandbox/ResourceLimiter.cs
@@ -49,6 +49,7 @@ public sealed class ResourceLimiter
         if (bytes <= 0)
             return;
 
+        var spin = new SpinWait();
         while (true)
         {
             var current = Interlocked.Read(ref _currentUsage);
@@ -64,7 +65,7 @@ public sealed class ResourceLimiter
 
             if (Interlocked.CompareExchange(ref _currentUsage, newUsage, current) == current)
                 return; // Successfully allocated
-            // Another thread changed _currentUsage — retry
+            spin.SpinOnce(); // Yield on contention instead of burning CPU
         }
     }
 

--- a/src/network/Basalt.Network/Gossip/EpisubService.cs
+++ b/src/network/Basalt.Network/Gossip/EpisubService.cs
@@ -22,15 +22,15 @@ public sealed class EpisubService
 
     // Message deduplication cache
     private readonly ConcurrentDictionary<Hash256, long> _seenMessages = new();
-    private const int MaxSeenMessages = 200_000;
-    private const long SeenMessageTtlMs = 120_000; // 2 minutes
+    private const int MaxSeenMessages = 50_000;
+    private const long SeenMessageTtlMs = 60_000; // 1 minute
 
     // IHAVE tracking: messages we've announced but not yet requested
     private readonly ConcurrentDictionary<Hash256, List<PeerId>> _ihaveSources = new();
 
     // Message content cache: stores serialized messages for IWANT responses
     private readonly ConcurrentDictionary<Hash256, byte[]> _messageCache = new();
-    private const int MaxCachedMessages = 50_000;
+    private const int MaxCachedMessages = 10_000;
 
     // Target counts
     private const int TargetEagerPeers = 6;
@@ -51,11 +51,12 @@ public sealed class EpisubService
     // NET-M18: Maximum IHAVE sources tracked per message ID
     private const int MaxIHaveSources = 3;
 
-    // Periodic cleanup: avoid O(n) scans on every insert by rate-limiting cleanup
-    // to at most once per CleanupCooldownMs, run on a background thread.
+    // Periodic cleanup: TTL-based proactive cleanup on a background timer,
+    // plus reactive cleanup when collections exceed their caps.
     private long _lastCleanupMs;
     private int _cleanupRunning;
-    private const long CleanupCooldownMs = 10_000; // 10 seconds
+    private const long CleanupCooldownMs = 5_000; // 5 seconds
+    private Timer? _cleanupTimer;
 
     public event Action<PeerId, byte[]>? OnSendMessage;
     public event Action<PeerId, NetworkMessage>? OnMessageReceived;
@@ -64,6 +65,16 @@ public sealed class EpisubService
     {
         _peerManager = peerManager;
         _logger = logger;
+
+        // Proactive TTL cleanup every 30 seconds — prevents unbounded cache growth
+        // even when message rate stays below the reactive cap threshold.
+        _cleanupTimer = new Timer(_ =>
+        {
+            if (Interlocked.CompareExchange(ref _cleanupRunning, 1, 0) != 0)
+                return;
+            try { CleanupSeenMessages(); }
+            finally { Interlocked.Exchange(ref _cleanupRunning, 0); }
+        }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
     }
 
     /// <summary>
@@ -145,15 +156,21 @@ public sealed class EpisubService
         // Cache the serialized message for IWANT responses
         CacheMessage(messageId, SerializeMessage(message));
 
-        // IHAVE to all peers (lazy protocol)
-        foreach (var peer in _peerManager.ConnectedPeers)
+        // IHAVE to eager + lazy peers (avoids ConnectedPeers snapshot allocation)
+        foreach (var (peerId, _) in _eagerPeers)
         {
-            if (excludePeer.HasValue && peer.Id == excludePeer.Value)
+            if (excludePeer.HasValue && peerId == excludePeer.Value)
                 continue;
-            SendIHave(peer.Id, messageId);
+            SendIHave(peerId, messageId);
+            RecordSentIHave(peerId, messageId);
+        }
 
-            // NET-M16: Track IHAVE sent to this peer for IWANT correlation
-            RecordSentIHave(peer.Id, messageId);
+        foreach (var (peerId, _) in _lazyPeers)
+        {
+            if (excludePeer.HasValue && peerId == excludePeer.Value)
+                continue;
+            SendIHave(peerId, messageId);
+            RecordSentIHave(peerId, messageId);
         }
     }
 

--- a/src/network/Basalt.Network/Gossip/EpisubService.cs
+++ b/src/network/Basalt.Network/Gossip/EpisubService.cs
@@ -73,6 +73,12 @@ public sealed class EpisubService
             if (Interlocked.CompareExchange(ref _cleanupRunning, 1, 0) != 0)
                 return;
             try { CleanupSeenMessages(); }
+            catch (Exception ex)
+            {
+                // Swallow to prevent process termination from unhandled ThreadPool exception.
+                // Timer will retry in 30 seconds.
+                _logger.LogWarning(ex, "Error during Episub message cache cleanup");
+            }
             finally { Interlocked.Exchange(ref _cleanupRunning, 0); }
         }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
     }

--- a/src/network/Basalt.Network/Gossip/EpisubService.cs
+++ b/src/network/Basalt.Network/Gossip/EpisubService.cs
@@ -9,7 +9,7 @@ namespace Basalt.Network.Gossip;
 /// Priority tier: Eager push for high-priority messages (consensus, priority txs) - target &lt;200ms.
 /// Standard tier: Lazy IHAVE/IWANT for standard txs and blocks - target &lt;600ms.
 /// </summary>
-public sealed class EpisubService
+public sealed class EpisubService : IDisposable
 {
     private readonly PeerManager _peerManager;
     private readonly ILogger<EpisubService> _logger;
@@ -525,5 +525,11 @@ public sealed class EpisubService
     private static byte[] SerializeMessage(NetworkMessage message)
     {
         return MessageCodec.Serialize(message);
+    }
+
+    public void Dispose()
+    {
+        _cleanupTimer?.Dispose();
+        _cleanupTimer = null;
     }
 }

--- a/src/network/Basalt.Network/GossipService.cs
+++ b/src/network/Basalt.Network/GossipService.cs
@@ -99,7 +99,8 @@ public sealed class GossipService
             return;
         MarkMessageSeen(msgId);
 
-        BroadcastToAll(message, null);
+        // Reuse already-serialized bytes instead of serializing again in BroadcastToAll
+        BroadcastRawToAll(serialized, null);
     }
 
     /// <summary>
@@ -169,8 +170,16 @@ public sealed class GossipService
     /// </summary>
     private void BroadcastToAll(NetworkMessage message, PeerId? excludePeer)
     {
+        BroadcastRawToAll(SerializeMessage(message), excludePeer);
+    }
+
+    /// <summary>
+    /// Broadcast pre-serialized bytes to connected peers with fan-out limit.
+    /// Avoids re-serializing when the caller already has the wire bytes (e.g. dedup path).
+    /// </summary>
+    private void BroadcastRawToAll(byte[] data, PeerId? excludePeer)
+    {
         var allPeers = _peerManager.ConnectedPeers;
-        var data = SerializeMessage(message);
 
         // Filter out the excluded peer
         var eligible = new List<PeerInfo>();

--- a/src/network/Basalt.Network/PeerInfo.cs
+++ b/src/network/Basalt.Network/PeerInfo.cs
@@ -98,15 +98,18 @@ public sealed class PeerInfo
 
     /// <summary>
     /// NET-M23: Adjust reputation score atomically using Interlocked.CompareExchange loop.
+    /// SpinWait yields the thread on contention to avoid burning CPU.
     /// </summary>
     public void AdjustReputation(int delta)
     {
+        var spin = new SpinWait();
         while (true)
         {
             int current = Volatile.Read(ref _reputationScore);
             int desired = Math.Clamp(current + delta, 0, 200);
             if (Interlocked.CompareExchange(ref _reputationScore, desired, current) == current)
                 break;
+            spin.SpinOnce();
         }
     }
 }

--- a/src/network/Basalt.Network/PeerManager.cs
+++ b/src/network/Basalt.Network/PeerManager.cs
@@ -14,6 +14,13 @@ public sealed class PeerManager
     private readonly ILogger<PeerManager> _logger;
     private readonly int _maxPeers;
 
+    // Cached connected-peer snapshot: avoids O(n) LINQ + List allocation on every access.
+    // Invalidated on any peer state change; lazily rebuilt on next read.
+    private volatile PeerInfo[] _connectedPeersCache = [];
+    private volatile int _connectedCountCache;
+    private long _cacheVersion;
+    private long _snapshotVersion = -1;
+
     public PeerManager(ILogger<PeerManager> logger, int maxPeers = 50)
     {
         _logger = logger;
@@ -21,10 +28,16 @@ public sealed class PeerManager
     }
 
     /// <summary>
-    /// Currently connected peers.
+    /// Currently connected peers (cached snapshot, allocation-free on repeated reads).
     /// </summary>
-    public IReadOnlyCollection<PeerInfo> ConnectedPeers =>
-        _peers.Values.Where(p => p.State == PeerState.Connected).ToList();
+    public IReadOnlyCollection<PeerInfo> ConnectedPeers
+    {
+        get
+        {
+            EnsureCacheFresh();
+            return _connectedPeersCache;
+        }
+    }
 
     /// <summary>
     /// All known peers.
@@ -32,9 +45,46 @@ public sealed class PeerManager
     public IReadOnlyCollection<PeerInfo> AllPeers => _peers.Values.ToList();
 
     /// <summary>
-    /// Number of connected peers.
+    /// Number of connected peers (O(1) cached).
     /// </summary>
-    public int ConnectedCount => _peers.Values.Count(p => p.State == PeerState.Connected);
+    public int ConnectedCount
+    {
+        get
+        {
+            EnsureCacheFresh();
+            return _connectedCountCache;
+        }
+    }
+
+    /// <summary>
+    /// Invalidate the connected-peers cache. Called on any state change.
+    /// </summary>
+    private void InvalidateCache()
+    {
+        Interlocked.Increment(ref _cacheVersion);
+    }
+
+    /// <summary>
+    /// Rebuild the cache if the version has changed since the last snapshot.
+    /// </summary>
+    private void EnsureCacheFresh()
+    {
+        var current = Volatile.Read(ref _cacheVersion);
+        if (current == Volatile.Read(ref _snapshotVersion))
+            return;
+
+        // Rebuild: single pass over _peers, no LINQ
+        var connected = new List<PeerInfo>();
+        foreach (var peer in _peers.Values)
+        {
+            if (peer.State == PeerState.Connected)
+                connected.Add(peer);
+        }
+
+        _connectedPeersCache = connected.ToArray();
+        _connectedCountCache = connected.Count;
+        Volatile.Write(ref _snapshotVersion, current);
+    }
 
     /// <summary>
     /// Add a peer from a static configuration.
@@ -50,6 +100,7 @@ public sealed class PeerManager
         };
 
         _peers.TryAdd(id, peer);
+        InvalidateCache();
         _logger.LogInformation("Added static peer {PeerId} at {Endpoint}", id, peer.Endpoint);
         return peer;
     }
@@ -92,6 +143,7 @@ public sealed class PeerManager
         peer.BannedUntil = null; // Clear any prior ban
 
         _peers.AddOrUpdate(peer.Id, peer, (_, _) => peer);
+        InvalidateCache();
         _logger.LogInformation("Peer {PeerId} connected from {Endpoint}", peer.Id, peer.Endpoint);
         return true;
     }
@@ -118,6 +170,7 @@ public sealed class PeerManager
         if (_peers.TryGetValue(id, out var peer))
         {
             peer.State = PeerState.Disconnected;
+            InvalidateCache();
             _logger.LogInformation("Peer {PeerId} disconnected: {Reason}", id, reason);
 
             // NET-L10: Notify listeners (e.g. EpisubService) to clean up peer sets
@@ -143,6 +196,7 @@ public sealed class PeerManager
             peer.State = PeerState.Banned;
             peer.ReputationScore = 0;
             peer.BannedUntil = DateTimeOffset.UtcNow + (duration ?? TimeSpan.FromHours(1));
+            InvalidateCache();
             _logger.LogWarning("Peer {PeerId} banned until {BannedUntil}: {Reason}",
                 id, peer.BannedUntil, reason);
 
@@ -194,7 +248,10 @@ public sealed class PeerManager
         }
 
         if (removed > 0)
+        {
+            InvalidateCache();
             _logger.LogInformation("Pruned {Count} inactive/expired-ban peers", removed);
+        }
 
         return removed;
     }

--- a/src/network/Basalt.Network/Transport/TcpTransport.cs
+++ b/src/network/Basalt.Network/Transport/TcpTransport.cs
@@ -380,6 +380,8 @@ public sealed class TcpTransport : IAsyncDisposable
             catch (SocketException ex)
             {
                 _logger.LogError(ex, "Error accepting TCP connection");
+                // Prevent tight spin on persistent listener errors (e.g., EMFILE)
+                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 

--- a/src/node/Basalt.Node/BlockApplier.cs
+++ b/src/node/Basalt.Node/BlockApplier.cs
@@ -155,6 +155,15 @@ public sealed class BlockApplier
         PersistBlock(block, rawBlockData, commitBitmap);
         PersistReceipts(block.Receipts);
 
+        // Compact canonical state DB tracking sets to prevent unbounded memory growth.
+        // _dirtyStorageKeys/_dirtyAccounts are only used by fork→parent merge and grow
+        // forever on the canonical instance. _deletedStorage/_deletedAccounts are redundant
+        // after the trie's Delete() removed the keys. Without this, these HashSets accumulate
+        // entries every block (especially from TWAP snapshot writes/prunes) and eventually
+        // cause Gen 2 GC pressure → 100% CPU on long-running nodes.
+        stateDb.ClearDirtyTracking();
+        stateDb.CompactDeletedSets();
+
         // Record commit participation
         _epochManager?.RecordBlockSigners(block.Number, commitBitmap);
 

--- a/src/node/Basalt.Node/BlockApplier.cs
+++ b/src/node/Basalt.Node/BlockApplier.cs
@@ -164,6 +164,9 @@ public sealed class BlockApplier
         stateDb.ClearDirtyTracking();
         stateDb.CompactDeletedSets();
 
+        // Process completed unbonding entries to prevent queue growth
+        _stakingState?.ProcessUnbonding(block.Number);
+
         // Record commit participation
         _epochManager?.RecordBlockSigners(block.Number, commitBitmap);
 
@@ -263,6 +266,12 @@ public sealed class BlockApplier
         var newlyApplied = applied - skippedAsAlreadyApplied;
         if (applied == blocks.Count && newlyApplied > 0)
         {
+            // Compact tracking sets on the fork before it becomes canonical.
+            // Without this, _dirtyStorageKeys/_deletedStorage accumulate on
+            // sync-only nodes (which never call ApplyBlock's cleanup path).
+            forkedState.ClearDirtyTracking();
+            forkedState.CompactDeletedSets();
+
             stateDbRef.Swap(forkedState);
             _logger.LogInformation("Synced {Count} blocks, now at #{Height}",
                 newlyApplied, _chainManager.LatestBlockNumber);

--- a/src/node/Basalt.Node/BlockApplier.cs
+++ b/src/node/Basalt.Node/BlockApplier.cs
@@ -197,6 +197,39 @@ public sealed class BlockApplier
         if (blocks.Count == 0)
             return 0;
 
+        // Fast path: if the first block is already applied by consensus, check if ALL
+        // are already applied. This avoids the expensive Fork() → ComputeStateRoot() call
+        // that otherwise runs on every sync attempt even when consensus already finalized
+        // these blocks. On a 4-validator idle chain, this saves ~3 Merkle trie rehashes
+        // per block per node.
+        var firstBlock = blocks[0].Block;
+        if (firstBlock.Number <= _chainManager.LatestBlockNumber)
+        {
+            var allAlreadyApplied = true;
+            foreach (var (block, raw, bitmap) in blocks)
+            {
+                var existing = _chainManager.GetBlockByNumber(block.Number);
+                if (existing == null || existing.Hash != block.Hash)
+                {
+                    allAlreadyApplied = false;
+                    break;
+                }
+            }
+
+            if (allAlreadyApplied)
+            {
+                // Still record epoch data for these blocks
+                foreach (var (block, _, bitmap) in blocks)
+                {
+                    _epochManager?.RecordBlockSigners(block.Number, bitmap);
+                    var newSet = _epochManager?.OnBlockFinalized(block.Number);
+                    if (newSet != null)
+                        ApplyEpochTransition(newSet, block.Number);
+                }
+                return blocks.Count;
+            }
+        }
+
         var forkedState = stateDbRef.Fork();
         var applied = 0;
 

--- a/src/node/Basalt.Node/BlockSyncService.cs
+++ b/src/node/Basalt.Node/BlockSyncService.cs
@@ -35,6 +35,7 @@ public sealed class BlockSyncService : ISyncStatus, IAsyncDisposable
     private int _syncLag;
     private int _backoffMs = 1000;
     private const int MaxBackoffMs = 30_000;
+    private const int MinPollDelayMs = 500; // Minimum delay between sync polls to reduce pressure on source
     private const int MaxForkSearchDepth = 1000;
     private int _consecutiveForkFailures;
 
@@ -148,6 +149,9 @@ public sealed class BlockSyncService : ISyncStatus, IAsyncDisposable
                     _logger.LogInformation(
                         "Synced {Count} blocks from source, now at #{Height} (lag: {Lag})",
                         applied, newLocalTip, SyncLag);
+
+                    // Throttle sync polls to avoid hammering the source when catching up
+                    await Task.Delay(MinPollDelayMs, ct);
                 }
                 else
                 {

--- a/src/node/Basalt.Node/NodeCoordinator.cs
+++ b/src/node/Basalt.Node/NodeCoordinator.cs
@@ -511,6 +511,15 @@ public sealed class NodeCoordinator : IAsyncDisposable
     {
         try
         {
+            // Updated bitmap for an already-finalized block (late-arriving COMMIT votes).
+            // Only update the epoch manager's record — don't re-apply the block.
+            if (blockData.Length == 0 && commitBitmap != 0)
+            {
+                _epochManager?.RecordBlockSigners(_chainManager.LatestBlockNumber, commitBitmap);
+                _blockStore?.PutCommitBitmap(_chainManager.LatestBlockNumber, commitBitmap);
+                return true;
+            }
+
             var block = BlockCodec.DeserializeBlock(blockData);
 
             // ── Race guard: if sync already applied this block, skip re-execution ──
@@ -746,6 +755,10 @@ public sealed class NodeCoordinator : IAsyncDisposable
     {
         if (_circuitBreakerTripped) return;
 
+        // Don't propose if we're not in the active validator set (e.g. slashed/deactivated)
+        if (_validatorSet == null || !_validatorSet.IsValidator(_localPeerId))
+            return;
+
         if (!_consensus!.IsLeader || _consensus.State != ConsensusState.Proposing)
             return;
 
@@ -779,6 +792,10 @@ public sealed class NodeCoordinator : IAsyncDisposable
     private void TryProposeBlockPipelined()
     {
         if (_circuitBreakerTripped) return;
+
+        // Don't propose if we're not in the active validator set (e.g. slashed/deactivated)
+        if (_validatorSet == null || !_validatorSet.IsValidator(_localPeerId))
+            return;
 
         // Block time pacing
         var elapsedMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - Volatile.Read(ref _lastBlockFinalizedAtMs);
@@ -1578,6 +1595,9 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 // M13: Update peer count metric
                 MetricsEndpoint.RecordPeerCount(connectedCount);
 
+                // Prune disconnected/expired-ban peers to prevent unbounded accumulation
+                _peerManager.PruneInactivePeers(TimeSpan.FromMinutes(5));
+
                 if (connectedCount < expectedPeerCount)
                 {
                     _logger.LogInformation("Only {Connected}/{Expected} peers connected, reconnecting...",
@@ -1907,18 +1927,27 @@ public sealed class NodeCoordinator : IAsyncDisposable
             // blocks without updating the consensus engine's _currentBlockNumber,
             // so without this restart, consensus would be stuck trying to decide a
             // block that was already applied via sync.
+            // Only restart if we're in the active validator set — deactivated nodes
+            // should follow via sync only, not waste resources running consensus rounds.
             var nextBlock = _chainManager.LatestBlockNumber + 1;
+            var isActiveValidator = _validatorSet != null && _validatorSet.IsValidator(_localPeerId);
             if (!_config.UsePipelining)
             {
                 _consensus!.StartRound(nextBlock);
-                _logger.LogInformation("Consensus restarted at block #{Block} after sync", nextBlock);
+                if (isActiveValidator)
+                    _logger.LogInformation("Consensus restarted at block #{Block} after sync", nextBlock);
+                else
+                    _logger.LogDebug("Sync complete at block #{Block} (not in active validator set)", nextBlock - 1);
             }
             else
             {
                 // Pipelined consensus tracks _lastFinalizedBlock internally.
                 // Clear stale rounds and let the pipeline restart from current height.
                 _pipelinedConsensus!.UpdateLastFinalizedBlock(_chainManager.LatestBlockNumber);
-                _logger.LogInformation("Pipelined consensus updated to block #{Block} after sync", _chainManager.LatestBlockNumber);
+                if (isActiveValidator)
+                    _logger.LogInformation("Pipelined consensus updated to block #{Block} after sync", _chainManager.LatestBlockNumber);
+                else
+                    _logger.LogDebug("Sync complete at block #{Block} (not in active validator set)", _chainManager.LatestBlockNumber);
             }
         }
     }

--- a/src/node/Basalt.Node/NodeCoordinator.cs
+++ b/src/node/Basalt.Node/NodeCoordinator.cs
@@ -1632,8 +1632,32 @@ public sealed class NodeCoordinator : IAsyncDisposable
 
     private async Task RunConsensusLoop(CancellationToken ct)
     {
-        // Wait for peers to connect
-        await Task.Delay(2000, ct);
+        // Wait for all validator identities to be resolved via handshake before entering
+        // consensus. Without this, a leader whose validator set still has placeholder BLS
+        // keys will silently drop votes from unresolved peers, causing those peers to miss
+        // the commit bitmap. Different leaders may have different placeholder states, leading
+        // to divergent inactivity slashing calculations at epoch boundaries — a fatal
+        // consistency violation that permanently splits the network.
+        var expectedPeers = _config.Peers.Length;
+        for (int wait = 0; wait < 30; wait++) // Up to 15 seconds
+        {
+            await Task.Delay(500, ct);
+            var resolvedCount = 0;
+            foreach (var v in _validatorSet!.Validators)
+            {
+                // A placeholder PeerId won't match any real connection
+                if (_peerManager!.GetPeer(v.PeerId) != null || v.PeerId == _localPeerId)
+                    resolvedCount++;
+            }
+            if (resolvedCount >= _validatorSet.Count)
+            {
+                _logger.LogInformation("All {Count} validator identities resolved, starting consensus", resolvedCount);
+                break;
+            }
+            if (wait % 4 == 3)
+                _logger.LogInformation("Waiting for validator identities: {Resolved}/{Total} resolved",
+                    resolvedCount, _validatorSet.Count);
+        }
 
         // Retry initial sync until caught up or no peers are ahead.
         // A single sync attempt can fail mid-way due to peer disconnects.

--- a/src/node/Basalt.Node/NodeCoordinator.cs
+++ b/src/node/Basalt.Node/NodeCoordinator.cs
@@ -465,9 +465,16 @@ public sealed class NodeCoordinator : IAsyncDisposable
 
         _consensus.OnBehindDetected += (blockNumber) =>
         {
-            _logger.LogWarning("Consensus detected we are behind (need block #{Block}). Triggering sync.",
-                blockNumber);
-            _ = Task.Run(() => TrySyncFromPeers(_cts?.Token ?? CancellationToken.None));
+            // Only sync when >1 block behind. A 1-block gap resolves via normal consensus
+            // flow (the leader's aggregate QC finalizes the block). Syncing for 1-block gaps
+            // wastes CPU on Fork+ComputeStateRoot.
+            var gap = blockNumber - _chainManager.LatestBlockNumber;
+            if (gap > 1)
+            {
+                _logger.LogWarning("Consensus detected we are behind (need block #{Block}, gap={Gap}). Triggering sync.",
+                    blockNumber, gap);
+                _ = Task.Run(() => TrySyncFromPeers(_cts?.Token ?? CancellationToken.None));
+            }
         };
 
         _logger.LogInformation("Consensus: sequential mode (BasaltBft)");
@@ -499,9 +506,13 @@ public sealed class NodeCoordinator : IAsyncDisposable
 
         _pipelinedConsensus.OnBehindDetected += (blockNumber) =>
         {
-            _logger.LogWarning("Pipelined consensus detected we are behind (need block #{Block}). Triggering sync.",
-                blockNumber);
-            _ = Task.Run(() => TrySyncFromPeers(_cts?.Token ?? CancellationToken.None));
+            var gap = blockNumber - _chainManager.LatestBlockNumber;
+            if (gap > 1)
+            {
+                _logger.LogWarning("Pipelined consensus detected we are behind (need block #{Block}, gap={Gap}). Triggering sync.",
+                    blockNumber, gap);
+                _ = Task.Run(() => TrySyncFromPeers(_cts?.Token ?? CancellationToken.None));
+            }
         };
 
         _logger.LogInformation("Consensus: pipelined mode (PipelinedConsensus)");
@@ -1251,10 +1262,15 @@ public sealed class NodeCoordinator : IAsyncDisposable
     {
         _peerManager!.UpdatePeerBestBlock(sender, announce.BlockNumber, announce.BlockHash);
 
-        // If we're behind, trigger a full sync.  Previously this sent a BlockRequestMessage,
-        // but the BlockPayloadMessage response was rejected by the N-04 anti-injection guard
-        // when not in sync mode, causing validators to get permanently stuck after falling behind.
-        if (announce.BlockNumber > _chainManager.LatestBlockNumber)
+        // Only trigger sync when meaningfully behind (>1 block). A 1-block gap is normal —
+        // it means the peer finalized the block slightly before us. Consensus will finalize
+        // it within ~1 second. Triggering sync for a 1-block gap causes expensive unnecessary
+        // work: Fork() computes Merkle state root, TCP round-trip fetches the block, ApplyBatch
+        // creates a fork state, and by the time it arrives consensus has already finalized it.
+        // With 3 peers broadcasting every block, this wastes ~3 Fork+ComputeStateRoot per block
+        // per node, saturating CPU on idle chains.
+        var gap = announce.BlockNumber - _chainManager.LatestBlockNumber;
+        if (gap > 1)
         {
             _ = Task.Run(() => TrySyncFromPeers(_cts?.Token ?? CancellationToken.None));
         }

--- a/src/node/Basalt.Node/NodeCoordinator.cs
+++ b/src/node/Basalt.Node/NodeCoordinator.cs
@@ -1642,6 +1642,9 @@ public sealed class NodeCoordinator : IAsyncDisposable
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error in reconnection loop");
+                // Prevent tight spin on persistent errors (e.g., socket exhaustion)
+                try { await Task.Delay(baseDelayMs, ct); }
+                catch (OperationCanceledException) { break; }
             }
         }
     }

--- a/src/node/Basalt.Node/NodeCoordinator.cs
+++ b/src/node/Basalt.Node/NodeCoordinator.cs
@@ -133,6 +133,9 @@ public sealed class NodeCoordinator : IAsyncDisposable
     private long _circuitBreakerTrippedAtMs;
     private const long CircuitBreakerCooldownMs = 30_000; // Auto-reset after 30s
 
+    // Sync cooldown: prevent fire-and-forget Task.Run spam from the consensus loop
+    private long _lastSyncAttemptMs;
+
     // Fork detection: binary search for fork point
     private (ulong RequestedBlock, TaskCompletionSource<(Hash256 Hash, bool HasBlock)> Tcs)? _forkHashPending;
     private const int MaxRollbackDepth = 1000;
@@ -597,7 +600,7 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 {
                     var currentView = block.Number;
                     var cutoff = currentView > 10 ? currentView - 10 : 0;
-                    foreach (var key in _proposalsByView.Keys.ToArray())
+                    foreach (var key in _proposalsByView.Keys)
                     {
                         if (key.View < cutoff)
                             _proposalsByView.TryRemove(key, out _);
@@ -709,7 +712,7 @@ public sealed class NodeCoordinator : IAsyncDisposable
 
             // N-10: Sliding window — retain evidence for last 10 views on epoch transition
             var cutoff = blockNumber > 10 ? blockNumber - 10 : 0;
-            foreach (var key in _proposalsByView.Keys.ToArray())
+            foreach (var key in _proposalsByView.Keys)
             {
                 if (key.View < cutoff)
                     _proposalsByView.TryRemove(key, out _);
@@ -1706,11 +1709,17 @@ public sealed class NodeCoordinator : IAsyncDisposable
                 // behind can still trigger sync during cooldown — otherwise small gaps
                 // cause a permanent stall when all validators trip their circuit breakers.
                 // The _isSyncing guard in TrySyncFromPeers prevents concurrent attempts.
-                var bestPeerCheck = GetBestPeer();
-                if (bestPeerCheck != null && bestPeerCheck.BestBlockNumber > _chainManager.LatestBlockNumber)
+                // Cooldown: limit sync attempts to at most once per second to avoid
+                // Task.Run allocation spam on every 200ms iteration.
+                var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                if (now - Volatile.Read(ref _lastSyncAttemptMs) >= 1000)
                 {
-                    // Fire-and-forget sync attempt; _isSyncing guard deduplicates
-                    _ = Task.Run(() => TrySyncFromPeers(ct), ct);
+                    var bestPeerCheck = GetBestPeer();
+                    if (bestPeerCheck != null && bestPeerCheck.BestBlockNumber > _chainManager.LatestBlockNumber)
+                    {
+                        Volatile.Write(ref _lastSyncAttemptMs, now);
+                        _ = Task.Run(() => TrySyncFromPeers(ct), ct);
+                    }
                 }
 
                 // Circuit breaker auto-reset: after cooldown, reset and attempt
@@ -2103,10 +2112,13 @@ public sealed class NodeCoordinator : IAsyncDisposable
     /// </summary>
     private void PruneProposalsByView(ulong currentView)
     {
-        // N-17: Thread-safe iteration with .ToArray() on ConcurrentDictionary
-        var staleKeys = _proposalsByView.Keys.ToArray().Where(k => k.View < currentView);
-        foreach (var key in staleKeys)
-            _proposalsByView.TryRemove(key, out _);
+        // N-17: ConcurrentDictionary enumerators are safe for concurrent modification —
+        // .ToArray() was wasting O(n) allocation on every finalization.
+        foreach (var key in _proposalsByView.Keys)
+        {
+            if (key.View < currentView)
+                _proposalsByView.TryRemove(key, out _);
+        }
     }
 
     private PeerInfo? GetBestPeer()

--- a/src/node/Basalt.Node/NodeCoordinator.cs
+++ b/src/node/Basalt.Node/NodeCoordinator.cs
@@ -248,6 +248,8 @@ public sealed class NodeCoordinator : IAsyncDisposable
         if (_transport != null)
             await _transport.DisposeAsync();
 
+        _episub?.Dispose();
+
         _logger.LogInformation("Node coordinator stopped.");
     }
 
@@ -1657,7 +1659,6 @@ public sealed class NodeCoordinator : IAsyncDisposable
         // the commit bitmap. Different leaders may have different placeholder states, leading
         // to divergent inactivity slashing calculations at epoch boundaries — a fatal
         // consistency violation that permanently splits the network.
-        var expectedPeers = _config.Peers.Length;
         for (int wait = 0; wait < 30; wait++) // Up to 15 seconds
         {
             await Task.Delay(500, ct);

--- a/src/storage/Basalt.Storage/FlatStateDb.cs
+++ b/src/storage/Basalt.Storage/FlatStateDb.cs
@@ -326,6 +326,9 @@ public sealed class FlatStateDb : IStateDatabase
     {
         _dirtyStorageKeys.Clear();
         _dirtyAccounts.Clear();
+        // Also clear the underlying TrieStateDb's tracking sets, which have their own
+        // _dirtyStorageKeys/_dirtyAccounts that grow independently.
+        _trie.ClearDirtyTracking();
     }
 
     /// <summary>

--- a/src/storage/Basalt.Storage/FlatStateDb.cs
+++ b/src/storage/Basalt.Storage/FlatStateDb.cs
@@ -394,30 +394,35 @@ public sealed class FlatStateDb : IStateDatabase
     }
 
     /// <summary>
-    /// Log a warning if either cache exceeds the size threshold.
-    /// This is a monitoring aid — no eviction is performed.
+    /// Hard cap for storage cache entries. When exceeded, the cache is cleared to prevent
+    /// unbounded memory growth on long-running nodes. Reads will repopulate from the trie
+    /// on demand. The threshold is set high enough to avoid impacting normal block processing.
+    /// </summary>
+    private const int MaxStorageCacheEntries = 500_000;
+
+    /// <summary>
+    /// Check cache size and evict if the storage cache exceeds the hard cap.
+    /// Without eviction, _storageCache grows monotonically (entries are added on every
+    /// read miss and write but only removed on delete) causing unbounded RAM growth.
     /// </summary>
     private void CheckCacheSize()
     {
-        if (_logger == null) return;
-
-        int accountCount = _accountCache.Count;
         int storageCount = _storageCache.Count;
 
-        if (accountCount > CacheSizeWarningThreshold)
+        if (storageCount > MaxStorageCacheEntries)
         {
-            _logger.LogWarning(
-                "FlatStateDb account cache size ({Count}) exceeds warning threshold ({Threshold}). " +
-                "Consider implementing cache eviction or increasing available memory.",
-                accountCount, CacheSizeWarningThreshold);
+            _storageCache.Clear();
+            _storageSlotsIndex.Clear();
+            _logger?.LogInformation(
+                "FlatStateDb storage cache evicted ({Count} entries exceeded {Max} cap). " +
+                "Reads will repopulate from trie on demand.",
+                storageCount, MaxStorageCacheEntries);
         }
-
-        if (storageCount > CacheSizeWarningThreshold)
+        else if (_logger != null && storageCount > CacheSizeWarningThreshold)
         {
             _logger.LogWarning(
-                "FlatStateDb storage cache size ({Count}) exceeds warning threshold ({Threshold}). " +
-                "Consider implementing cache eviction or increasing available memory.",
-                storageCount, CacheSizeWarningThreshold);
+                "FlatStateDb storage cache size ({Count}) approaching eviction threshold ({Max})",
+                storageCount, MaxStorageCacheEntries);
         }
     }
 }

--- a/src/storage/Basalt.Storage/FlatStateDb.cs
+++ b/src/storage/Basalt.Storage/FlatStateDb.cs
@@ -316,25 +316,48 @@ public sealed class FlatStateDb : IStateDatabase
     public IReadOnlyCollection<Address> GetModifiedAccounts() => _dirtyAccounts;
 
     /// <summary>
+    /// Clear the dirty-tracking sets (<see cref="_dirtyStorageKeys"/> and <see cref="_dirtyAccounts"/>).
+    /// Call on the <b>canonical</b> FlatStateDb after each block finalization to prevent
+    /// unbounded growth. These sets are only consumed by
+    /// <see cref="TransactionExecutor.MergeForkState"/> which operates on <b>forks</b>,
+    /// not the canonical instance — so clearing them on the canonical DB is always safe.
+    /// </summary>
+    public void ClearDirtyTracking()
+    {
+        _dirtyStorageKeys.Clear();
+        _dirtyAccounts.Clear();
+    }
+
+    /// <summary>
+    /// Compact the deletion guard sets (<see cref="_deletedStorage"/> and <see cref="_deletedAccounts"/>).
+    /// Safe to call because <see cref="DeleteStorage"/> and <see cref="DeleteAccount"/> also
+    /// call the underlying <see cref="TrieStateDb"/> Delete, which removes the key from the
+    /// trie structure. After that, trie reads for deleted keys already return <c>null</c>,
+    /// making the flat-cache guard redundant. Without compaction these sets grow unboundedly
+    /// (one entry per TWAP prune per block) and contribute to memory pressure that triggers
+    /// aggressive Gen 2 GC → 100% CPU.
+    /// </summary>
+    public void CompactDeletedSets()
+    {
+        _deletedStorage.Clear();
+        _deletedAccounts.Clear();
+    }
+
+    /// <summary>
     /// Flush the current flat cache to persistent storage, including deletions.
     /// Call on shutdown or periodically after block finalization.
     /// </summary>
-    /// <remarks>
-    /// <para><b>M-06 fix:</b> Deletion sets are <b>not</b> cleared after flush.
-    /// Although the persisted store has the deletions applied, the underlying
-    /// <see cref="TrieStateDb"/> still contains the old data (trie nodes are never pruned).
-    /// Clearing the deletion sets would cause subsequent reads to fall through to the trie
-    /// and return stale data for entries that were deleted.</para>
-    /// </remarks>
     public void FlushToPersistence()
     {
         if (_persistence == null) return;
 
         _persistence.Flush(_accountCache, _storageCache, _deletedAccounts, _deletedStorage);
 
-        // M-06: Do NOT clear _deletedAccounts / _deletedStorage here.
-        // The trie still contains the old nodes, so the deletion guard must remain
-        // active to prevent fallthrough reads returning stale data.
+        // After flush, compact deletion sets — the persisted store has the deletions
+        // applied, and the trie's Delete() also removed the keys from the trie structure.
+        // Keeping stale tombstones causes unbounded memory growth on long-running nodes.
+        CompactDeletedSets();
+        ClearDirtyTracking();
     }
 
     /// <summary>

--- a/src/storage/Basalt.Storage/IStateDatabase.cs
+++ b/src/storage/Basalt.Storage/IStateDatabase.cs
@@ -47,6 +47,20 @@ public interface IStateDatabase
     /// contract address) from a fork back to canonical state — including native transfer recipients.
     /// </summary>
     IReadOnlyCollection<Address> GetModifiedAccounts() => [];
+
+    /// <summary>
+    /// Clear dirty-tracking sets after block finalization to prevent unbounded memory growth.
+    /// Only meaningful on the canonical instance; forks are short-lived and discarded.
+    /// Default implementation is a no-op for implementations that don't track dirty state.
+    /// </summary>
+    void ClearDirtyTracking() { }
+
+    /// <summary>
+    /// Compact deletion guard sets to prevent unbounded memory growth.
+    /// Safe when the underlying store also reflects the deletions.
+    /// Default implementation is a no-op.
+    /// </summary>
+    void CompactDeletedSets() { }
 }
 
 /// <summary>

--- a/src/storage/Basalt.Storage/RocksDb/RocksDbStore.cs
+++ b/src/storage/Basalt.Storage/RocksDb/RocksDbStore.cs
@@ -51,20 +51,41 @@ public sealed class RocksDbStore : IDisposable
         // Conservative write buffer sizes to keep total memtable memory under ~320MB
         // across all column families, leaving headroom for the application heap.
         // Point-lookup-heavy CFs get bloom filters to reduce unnecessary disk reads.
-        var defaultOptions = new ColumnFamilyOptions();
+
+        // Shared LRU block cache across all column families.
+        // Without this, RocksDB creates an unbounded per-CF cache whose native memory
+        // grows proportionally to on-disk data (SST index/filter blocks, data blocks).
+        var blockCache = RocksDbSharp.Native.Instance.rocksdb_cache_create_lru(new UIntPtr(64 * 1024 * 1024)); // 64 MB shared
+
+        var defaultTableOptions = new BlockBasedTableOptions()
+            .SetBlockCache(blockCache)
+            .SetCacheIndexAndFilterBlocks(true);
+
+        var defaultOptions = new ColumnFamilyOptions()
+            .SetBlockBasedTableFactory(defaultTableOptions);
+
+        var pointLookupTableOptions = new BlockBasedTableOptions()
+            .SetBlockCache(blockCache)
+            .SetCacheIndexAndFilterBlocks(true);
 
         var pointLookupOptions = new ColumnFamilyOptions()
             .SetBloomLocality(1)
             .SetWriteBufferSize(16UL * 1024 * 1024)      // 16MB write buffer (was 64MB)
             .SetMaxWriteBufferNumber(2)                    // 2 buffers (was 3)
-            .SetTargetFileSizeBase(32UL * 1024 * 1024);   // 32MB SST files (was 64MB)
+            .SetTargetFileSizeBase(32UL * 1024 * 1024)    // 32MB SST files (was 64MB)
+            .SetBlockBasedTableFactory(pointLookupTableOptions);
 
         // TrieNodes CF: write-heavy, point lookup — moderate buffers
+        var trieTableOptions = new BlockBasedTableOptions()
+            .SetBlockCache(blockCache)
+            .SetCacheIndexAndFilterBlocks(true);
+
         var trieOptions = new ColumnFamilyOptions()
             .SetBloomLocality(1)
             .SetWriteBufferSize(32UL * 1024 * 1024)       // 32MB write buffer (was 128MB)
             .SetMaxWriteBufferNumber(3)                     // 3 buffers (was 4)
-            .SetTargetFileSizeBase(64UL * 1024 * 1024);    // 64MB SST files (was 128MB)
+            .SetTargetFileSizeBase(64UL * 1024 * 1024)     // 64MB SST files (was 128MB)
+            .SetBlockBasedTableFactory(trieTableOptions);
 
         var cfs = new RocksDbSharp.ColumnFamilies();
         cfs.Add("default", defaultOptions);

--- a/src/storage/Basalt.Storage/RocksDb/RocksDbStore.cs
+++ b/src/storage/Basalt.Storage/RocksDb/RocksDbStore.cs
@@ -11,6 +11,7 @@ public sealed class RocksDbStore : IDisposable
 {
     private readonly RocksDbSharp.RocksDb _db;
     private readonly Dictionary<string, ColumnFamilyHandle> _columnFamilies;
+    private readonly IntPtr _blockCache;
 
     /// <summary>
     /// Column family names.
@@ -55,17 +56,17 @@ public sealed class RocksDbStore : IDisposable
         // Shared LRU block cache across all column families.
         // Without this, RocksDB creates an unbounded per-CF cache whose native memory
         // grows proportionally to on-disk data (SST index/filter blocks, data blocks).
-        var blockCache = RocksDbSharp.Native.Instance.rocksdb_cache_create_lru(new UIntPtr(64 * 1024 * 1024)); // 64 MB shared
+        _blockCache = RocksDbSharp.Native.Instance.rocksdb_cache_create_lru(new UIntPtr(64 * 1024 * 1024)); // 64 MB shared
 
         var defaultTableOptions = new BlockBasedTableOptions()
-            .SetBlockCache(blockCache)
+            .SetBlockCache(_blockCache)
             .SetCacheIndexAndFilterBlocks(true);
 
         var defaultOptions = new ColumnFamilyOptions()
             .SetBlockBasedTableFactory(defaultTableOptions);
 
         var pointLookupTableOptions = new BlockBasedTableOptions()
-            .SetBlockCache(blockCache)
+            .SetBlockCache(_blockCache)
             .SetCacheIndexAndFilterBlocks(true);
 
         var pointLookupOptions = new ColumnFamilyOptions()
@@ -77,7 +78,7 @@ public sealed class RocksDbStore : IDisposable
 
         // TrieNodes CF: write-heavy, point lookup — moderate buffers
         var trieTableOptions = new BlockBasedTableOptions()
-            .SetBlockCache(blockCache)
+            .SetBlockCache(_blockCache)
             .SetCacheIndexAndFilterBlocks(true);
 
         var trieOptions = new ColumnFamilyOptions()
@@ -189,6 +190,8 @@ public sealed class RocksDbStore : IDisposable
     public void Dispose()
     {
         _db.Dispose();
+        if (_blockCache != IntPtr.Zero)
+            RocksDbSharp.Native.Instance.rocksdb_cache_destroy(_blockCache);
     }
 }
 

--- a/src/storage/Basalt.Storage/RocksDb/RocksDbStore.cs
+++ b/src/storage/Basalt.Storage/RocksDb/RocksDbStore.cs
@@ -35,13 +35,16 @@ public sealed class RocksDbStore : IDisposable
 
     public RocksDbStore(string path)
     {
-        // M12: Production-ready RocksDB options
+        // M12: Production-ready RocksDB options.
+        // Cap background threads at 2 compaction + 1 flush to prevent CPU saturation
+        // on small VMs. IncreaseParallelism is capped at 4 regardless of core count.
+        var parallelism = Math.Min(Environment.ProcessorCount, 4);
         var options = new DbOptions()
             .SetCreateIfMissing(true)
             .SetCreateMissingColumnFamilies(true)
-            .SetMaxBackgroundCompactions(4)
-            .SetMaxBackgroundFlushes(2)
-            .IncreaseParallelism(Environment.ProcessorCount);
+            .SetMaxBackgroundCompactions(2)
+            .SetMaxBackgroundFlushes(1)
+            .IncreaseParallelism(parallelism);
 
         // M-01: Per-CF options tuned for each access pattern.
         // Point-lookup-heavy CFs get bloom filters to reduce unnecessary disk reads.

--- a/src/storage/Basalt.Storage/RocksDb/RocksDbStore.cs
+++ b/src/storage/Basalt.Storage/RocksDb/RocksDbStore.cs
@@ -36,32 +36,35 @@ public sealed class RocksDbStore : IDisposable
     public RocksDbStore(string path)
     {
         // M12: Production-ready RocksDB options.
-        // Cap background threads at 2 compaction + 1 flush to prevent CPU saturation
-        // on small VMs. IncreaseParallelism is capped at 4 regardless of core count.
-        var parallelism = Math.Min(Environment.ProcessorCount, 4);
+        // Background threads scaled to core count to avoid saturating the machine
+        // with compaction work on idle chains.
+        var cores = Environment.ProcessorCount;
+        var compactionThreads = Math.Clamp(cores - 1, 1, 2);
         var options = new DbOptions()
             .SetCreateIfMissing(true)
             .SetCreateMissingColumnFamilies(true)
-            .SetMaxBackgroundCompactions(2)
+            .SetMaxBackgroundCompactions(compactionThreads)
             .SetMaxBackgroundFlushes(1)
-            .IncreaseParallelism(parallelism);
+            .IncreaseParallelism(Math.Min(cores, 4));
 
         // M-01: Per-CF options tuned for each access pattern.
+        // Conservative write buffer sizes to keep total memtable memory under ~320MB
+        // across all column families, leaving headroom for the application heap.
         // Point-lookup-heavy CFs get bloom filters to reduce unnecessary disk reads.
         var defaultOptions = new ColumnFamilyOptions();
 
         var pointLookupOptions = new ColumnFamilyOptions()
             .SetBloomLocality(1)
-            .SetWriteBufferSize(64UL * 1024 * 1024)     // 64MB write buffer
-            .SetMaxWriteBufferNumber(3)
-            .SetTargetFileSizeBase(64UL * 1024 * 1024);  // 64MB SST files
+            .SetWriteBufferSize(16UL * 1024 * 1024)      // 16MB write buffer (was 64MB)
+            .SetMaxWriteBufferNumber(2)                    // 2 buffers (was 3)
+            .SetTargetFileSizeBase(32UL * 1024 * 1024);   // 32MB SST files (was 64MB)
 
-        // TrieNodes CF: write-heavy, point lookup — larger buffers
+        // TrieNodes CF: write-heavy, point lookup — moderate buffers
         var trieOptions = new ColumnFamilyOptions()
             .SetBloomLocality(1)
-            .SetWriteBufferSize(128UL * 1024 * 1024)     // 128MB write buffer
-            .SetMaxWriteBufferNumber(4)
-            .SetTargetFileSizeBase(128UL * 1024 * 1024);  // 128MB SST files
+            .SetWriteBufferSize(32UL * 1024 * 1024)       // 32MB write buffer (was 128MB)
+            .SetMaxWriteBufferNumber(3)                     // 3 buffers (was 4)
+            .SetTargetFileSizeBase(64UL * 1024 * 1024);    // 64MB SST files (was 128MB)
 
         var cfs = new RocksDbSharp.ColumnFamilies();
         cfs.Add("default", defaultOptions);

--- a/src/storage/Basalt.Storage/StateDbRef.cs
+++ b/src/storage/Basalt.Storage/StateDbRef.cs
@@ -62,4 +62,8 @@ public sealed class StateDbRef : IStateDatabase
     public IReadOnlyCollection<(Address Contract, Hash256 Key)> GetModifiedStorageKeys() => _inner.GetModifiedStorageKeys();
 
     public IReadOnlyCollection<Address> GetModifiedAccounts() => _inner.GetModifiedAccounts();
+
+    public void ClearDirtyTracking() => _inner.ClearDirtyTracking();
+
+    public void CompactDeletedSets() => _inner.CompactDeletedSets();
 }

--- a/src/storage/Basalt.Storage/Trie/MerklePatriciaTrie.cs
+++ b/src/storage/Basalt.Storage/Trie/MerklePatriciaTrie.cs
@@ -243,6 +243,11 @@ public sealed class MerklePatriciaTrie
             {
                 if (path.Equals(node.Path))
                 {
+                    // Short-circuit: if the value is identical, the hash is unchanged —
+                    // skip the BLAKE3 rehash + store write entirely.
+                    if (node.Value != null && value.AsSpan().SequenceEqual(node.Value))
+                        return nodeHash;
+
                     // Update existing leaf
                     var newLeaf = TrieNode.CreateLeaf(path, value);
                     var hash = newLeaf.ComputeHash();

--- a/src/storage/Basalt.Storage/TrieStateDb.cs
+++ b/src/storage/Basalt.Storage/TrieStateDb.cs
@@ -179,6 +179,18 @@ public sealed class TrieStateDb : IStateDatabase
     public IReadOnlyCollection<Address> GetModifiedAccounts() => _dirtyAccounts;
 
     /// <summary>
+    /// Clear dirty tracking sets to prevent unbounded growth on the canonical instance.
+    /// Without this, _dirtyStorageKeys and _dirtyAccounts accumulate one entry per
+    /// storage write / account modification per block — growing forever and causing
+    /// GC pressure that degrades to 100% CPU after hours of operation.
+    /// </summary>
+    public void ClearDirtyTracking()
+    {
+        _dirtyStorageKeys.Clear();
+        _dirtyAccounts.Clear();
+    }
+
+    /// <summary>
     /// Generate a Merkle proof for an account.
     /// </summary>
     public MerkleProof? GenerateAccountProof(Address address)

--- a/src/storage/Basalt.Storage/TrieStateDb.cs
+++ b/src/storage/Basalt.Storage/TrieStateDb.cs
@@ -58,11 +58,14 @@ public sealed class TrieStateDb : IStateDatabase
 
     public Hash256 ComputeStateRoot()
     {
-        // Flush any pending storage trie changes into account states
+        // Flush any pending storage trie changes into account states.
+        // Only write back accounts whose StorageRoot actually changed —
+        // avoids unnecessary BLAKE3 rehashing of the entire trie path
+        // when no storage mutations occurred (e.g. empty blocks).
         foreach (var (address, storageTrie) in _storageTries)
         {
             var account = GetAccount(address);
-            if (account.HasValue)
+            if (account.HasValue && account.Value.StorageRoot != storageTrie.RootHash)
             {
                 var updated = new AccountState
                 {

--- a/src/storage/Basalt.Storage/TrieStateDb.cs
+++ b/src/storage/Basalt.Storage/TrieStateDb.cs
@@ -17,6 +17,13 @@ public sealed class TrieStateDb : IStateDatabase
     private readonly HashSet<(Address, Hash256)> _dirtyStorageKeys = new();
     private readonly HashSet<Address> _dirtyAccounts = new();
 
+    /// <summary>
+    /// Cached state root — set after <see cref="ComputeStateRoot"/> and invalidated on any write.
+    /// Avoids expensive trie walks in <see cref="Fork"/> when the state hasn't changed
+    /// (e.g., consecutive empty blocks on an idle chain).
+    /// </summary>
+    private Hash256? _cachedStateRoot;
+
     public TrieStateDb(ITrieNodeStore nodeStore) : this(nodeStore, Hash256.Zero) { }
 
     public TrieStateDb(ITrieNodeStore nodeStore, Hash256 stateRoot)
@@ -40,6 +47,7 @@ public sealed class TrieStateDb : IStateDatabase
         var data = EncodeAccountState(state);
         _worldTrie.Put(key, data);
         _dirtyAccounts.Add(address);
+        _cachedStateRoot = null;
     }
 
     public bool AccountExists(Address address)
@@ -54,10 +62,15 @@ public sealed class TrieStateDb : IStateDatabase
         _worldTrie.Delete(key);
         _storageTries.Remove(address);
         _dirtyAccounts.Add(address);
+        _cachedStateRoot = null;
     }
 
     public Hash256 ComputeStateRoot()
     {
+        // Fast path: if no writes have occurred since last computation, return cached root.
+        if (_cachedStateRoot.HasValue)
+            return _cachedStateRoot.Value;
+
         // Flush any pending storage trie changes into account states.
         // Only write back accounts whose StorageRoot actually changed —
         // avoids unnecessary BLAKE3 rehashing of the entire trie path
@@ -81,7 +94,15 @@ public sealed class TrieStateDb : IStateDatabase
             }
         }
 
-        return _worldTrie.RootHash;
+        // Release storage trie objects after flushing their roots into account state.
+        // They hold references to trie nodes and can accumulate significant memory over
+        // thousands of blocks (TWAP snapshots create/delete storage keys every block).
+        // GetOrCreateStorageTrie will reconstruct them on-demand from the committed
+        // storage root, so clearing is always safe after flush.
+        _storageTries.Clear();
+
+        _cachedStateRoot = _worldTrie.RootHash;
+        return _cachedStateRoot.Value;
     }
 
     /// <summary>
@@ -140,6 +161,7 @@ public sealed class TrieStateDb : IStateDatabase
         key.WriteTo(storageKey);
         trie.Put(storageKey, value);
         _dirtyStorageKeys.Add((contract, key));
+        _cachedStateRoot = null;
     }
 
     public void DeleteStorage(Address contract, Hash256 key)
@@ -149,6 +171,7 @@ public sealed class TrieStateDb : IStateDatabase
         key.WriteTo(storageKey);
         trie.Delete(storageKey);
         _dirtyStorageKeys.Add((contract, key));
+        _cachedStateRoot = null;
     }
 
     public IReadOnlyCollection<(Address Contract, Hash256 Key)> GetModifiedStorageKeys() => _dirtyStorageKeys;

--- a/tests/Basalt.Consensus.Tests/BasaltBftTests.cs
+++ b/tests/Basalt.Consensus.Tests/BasaltBftTests.cs
@@ -180,9 +180,10 @@ public class BasaltBftTests
         foreach (var vote in commitVotes)
             bfts[leaderIndex].HandleVote(vote);
 
-        // Leader should have finalized and built a COMMIT aggregate QC
-        aggregates.Should().ContainSingle(a => a.Phase == VotePhase.Commit);
-        var commitQC = aggregates.First(a => a.Phase == VotePhase.Commit);
+        // Leader should have finalized and built a COMMIT aggregate QC.
+        // May contain an updated aggregate if late-arriving votes improved the bitmap.
+        aggregates.Should().Contain(a => a.Phase == VotePhase.Commit);
+        var commitQC = aggregates.Last(a => a.Phase == VotePhase.Commit);
         bfts[leaderIndex].State.Should().Be(ConsensusState.Finalized);
 
         // Non-leaders receive COMMIT QC and finalize


### PR DESCRIPTION
## Summary

Fixes critical consensus, performance, and memory issues discovered through validator log analysis on a 4-node Docker devnet. The chain previously halted permanently after ~1.5 hours due to validator set divergence, and CPU saturated at 100% on idle chains.

**Before:** chain halts at ~3,300 blocks, 100% CPU, ~50 MB/hour RAM growth
**After:** 36+ hours stable, healthy CPU, bounded RAM

## Root Causes & Fixes

### Consensus Stability
- **COMMIT bitmap race condition** — When COMMIT quorum (3/4) was reached, the aggregate was built immediately; the 4th validator's vote (on a concurrent TCP thread) was excluded from the bitmap. Over thousands of blocks, the same validators consistently lost the race, got slashed below the inactivity threshold, and were permanently deactivated. Different leaders had different placeholder BLS key states, causing each node to slash different validators — producing **divergent validator sets** that could never reconverge, permanently halting the chain.
  - Re-aggregate COMMIT QC when late votes arrive after quorum
  - Accept updated COMMIT aggregates on non-leader nodes
  - Wait up to 15s for all validator identities (BLS keys) to resolve via P2P handshake before starting consensus
  - Log BLS key mismatches that were previously completely silent
  - Re-activate validators when stake recovers above minimum after slashing
  - Guard block proposals with validator set membership check

### CPU Saturation
- **Unnecessary sync on 1-block gaps** — Every block announce from 3 peers triggered `TrySyncFromPeers()`, each calling `Fork()` → `ComputeStateRoot()` (expensive Merkle trie rehashing). 12+ wasted state root computations per block.
- **Double message serialization** — `BroadcastConsensusMessage` serialized for dedup hash, then `BroadcastToAll` serialized again for sending.
- **Fork for already-applied blocks** — Sync `ApplyBatch` called `Fork()` even when all blocks were already finalized by consensus.
- **TrieStateDb dirty tracking never cleared** — `_dirtyStorageKeys` and `_dirtyAccounts` on the TrieStateDb layer grew unboundedly (the FlatStateDb cleanup never forwarded to the inner trie), causing escalating GC pressure → 100% CPU after hours.
- **Error handler spin risks** — ReconnectLoop and TCP AcceptLoop had catch blocks that continued without delay on persistent errors.

### Memory Growth
- **RocksDB unbounded block cache** — No block cache limit was configured; native memory grew ~50 MB/hour as SST index/filter blocks scaled with on-disk data. Added 64 MB shared LRU cache with `CacheIndexAndFilterBlocks`.
- **FlatStateDb storage cache unbounded** — `_storageCache` grew monotonically with no eviction. Added 500K entry hard cap with full eviction.
- **Sync path missing dirty tracking cleanup** — `ApplyBatch` never called `ClearDirtyTracking()`/`CompactDeletedSets()` on the forked state before swap.
- **PruneInactivePeers never called** — Disconnected peers accumulated forever.
- **ProcessUnbonding never called** — Unbonding queue grew with every unstake.
- **SlashingEngine history unbounded** — Capped at 10K entries.
- **EpisubService timer crash risk** — Unhandled exception in cleanup callback would terminate the process.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — all tests pass across 16 projects
- [x] 4-validator Docker devnet: 36+ hours uptime, stable consensus
- [x] First epoch transition (block 100): all 4 validators survive, quorum 3/3
- [x] CPU stable (no 100% saturation)
- [x] RAM bounded (no 50 MB/hour growth)
- [x] No "Vote from non-validator" or "Invalid aggregate signature" warnings
- [x] No "BLS key mismatch" warnings (identity wait works)